### PR TITLE
Add standalone email plugins with provider abstraction

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal plugin marketplace for Claude Code",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -43,6 +43,30 @@
       "version": "1.1.0",
       "keywords": ["credit-cards", "benefits", "travel-credits", "amex-platinum", "venture-x", "sapphire-reserve", "delta-reserve", "alaska-atmos", "ynab"],
       "category": "finance"
+    },
+    {
+      "name": "inbox-to-reminder",
+      "source": "./plugins/inbox-to-reminder",
+      "description": "Scan email inbox for action items and create reminders in Apple Reminders",
+      "version": "1.0.0",
+      "keywords": ["email", "reminders", "tasks", "bills", "deadlines"],
+      "category": "productivity"
+    },
+    {
+      "name": "newsletter-unsubscriber",
+      "source": "./plugins/newsletter-unsubscriber",
+      "description": "Scan inbox for newsletters and help unsubscribe from unwanted ones",
+      "version": "1.0.0",
+      "keywords": ["email", "newsletters", "unsubscribe", "cleanup"],
+      "category": "productivity"
+    },
+    {
+      "name": "inbox-to-parcel",
+      "source": "./plugins/inbox-to-parcel",
+      "description": "Process shipping emails and add tracking to Parcel app",
+      "version": "1.0.0",
+      "keywords": ["email", "packages", "tracking", "parcel", "shipping"],
+      "category": "productivity"
     }
   ]
 }

--- a/plugins/inbox-to-parcel/.claude-plugin/plugin.json
+++ b/plugins/inbox-to-parcel/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "inbox-to-parcel",
+  "version": "1.0.0",
+  "description": "Process shipping emails and add tracking to Parcel app",
+  "author": {
+    "name": "Omar Shahine"
+  },
+  "license": "MIT"
+}

--- a/plugins/inbox-to-parcel/.claude/settings.local.json
+++ b/plugins/inbox-to-parcel/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Write(data/**)",
+      "Edit(data/**)"
+    ]
+  }
+}

--- a/plugins/inbox-to-parcel/.mcp.json
+++ b/plugins/inbox-to-parcel/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp", "--headless", "--browser", "chrome"]
+    }
+  }
+}

--- a/plugins/inbox-to-parcel/README.md
+++ b/plugins/inbox-to-parcel/README.md
@@ -1,0 +1,87 @@
+# inbox-to-parcel
+
+Process shipping notification emails and add tracking to Parcel app.
+
+## Features
+
+- Scans inbox for shipment notification emails
+- Extracts tracking numbers and carrier information
+- Uses Playwright for web-based tracking links when needed
+- Adds deliveries to Parcel app via API
+- Moves processed emails to the Orders folder
+- Handles Amazon emails specially (auto-sync to Parcel, but still organizes)
+- Archives order confirmations to Orders folder
+- Supports multiple email providers (Fastmail, Gmail, Outlook)
+
+## Setup
+
+Run the setup command to configure your providers:
+
+```
+/inbox-to-parcel:setup
+```
+
+## Usage
+
+```
+/inbox-to-parcel:track              # Process recent shipping emails
+/inbox-to-parcel:track --days 14    # Look back 14 days
+```
+
+## Requirements
+
+### MCP Servers
+
+- **Email Provider** (one of):
+  - `fastmail` - Fastmail MCP server
+  - `gmail` - Gmail MCP server (via Smithery)
+  - `outlook` - Outlook MCP server (via Smithery)
+
+- **Package Tracking**:
+  - `parcel-api-mcp` - Parcel app API
+  - Install: `npx -y @smithery/cli@latest install @NOVA-3951/parcel-api-mcp --client claude`
+  - Requires API key from: https://web.parcelapp.net/#apiPanel
+
+- **Browser Automation**:
+  - `playwright` - For web-based tracking extraction (bundled in plugin)
+
+## Configuration
+
+Provider settings are stored in `data/settings.yaml`. The setup command will configure this for you.
+
+## Data Files
+
+- `data/shipping-patterns.json` - Patterns for detecting shipping emails
+- `data/settings.yaml` - Provider configuration
+
+## How It Works
+
+1. **Gets existing deliveries** from Parcel to avoid duplicates
+2. **Scans inbox** for shipment notification emails (INBOX only)
+3. **Extracts tracking info** from emails or web-based tracking links
+4. **Adds new deliveries** to Parcel app via API
+5. **Moves processed emails** to the Orders folder
+
+## Supported Carriers
+
+| Carrier | Code |
+|---------|------|
+| UPS | ups |
+| FedEx | fedex |
+| USPS | usps |
+| DHL Express | dhl |
+| DHL eCommerce | dhlecom |
+| OnTrac | ont |
+| LaserShip | laser |
+| UPS Mail Innovations | upsmi |
+
+## Special Handling
+
+- **Amazon emails**: Skipped for Parcel (auto-syncs), but moved to Orders folder
+- **Order confirmations**: Moved to Orders folder even without tracking numbers
+- **Duplicates**: Automatically detected and skipped to preserve API rate limits
+
+## Rate Limits
+
+- Parcel API: 20 add requests per day
+- Always checks for duplicates before adding to avoid wasting calls

--- a/plugins/inbox-to-parcel/agents/inbox-to-parcel.md
+++ b/plugins/inbox-to-parcel/agents/inbox-to-parcel.md
@@ -1,0 +1,306 @@
+---
+description: "Process order/shipment emails and add tracking information to Parcel app. This includes:\n\n- Scanning inbox for shipment notification emails\n- Extracting tracking numbers and carrier information\n- Using Playwright to fetch tracking details from links in emails when needed\n- Adding deliveries to Parcel app via API\n- Moving processed emails to the Orders folder\n- Archiving Amazon order/shipment emails to Orders folder (they auto-sync to Parcel, but still need organizing)\n\nExamples:\n\n<example>\nuser: \"Check my inbox for shipping notifications and add them to Parcel\"\nassistant: \"I'll use the inbox-to-parcel agent to scan your inbox for shipment emails, extract tracking info, and add them to Parcel.\"\n</example>\n\n<example>\nuser: \"Process my recent order confirmations\"\nassistant: \"Let me use the inbox-to-parcel agent to find order emails with tracking numbers and add them to Parcel.\"\n</example>\n\n<example>\nuser: \"Add my tracking numbers to Parcel from recent emails\"\nassistant: \"I'll launch the inbox-to-parcel agent to extract tracking information and add deliveries to Parcel.\"\n</example>"
+model: opus
+color: orange
+allowedTools: "*"
+---
+
+You are an expert order tracking and delivery management specialist. Your role is to scan email inboxes for shipment notifications, extract tracking information, and add deliveries to the Parcel app.
+
+## Provider Configuration
+
+This plugin supports multiple email and package tracking providers. Before starting, read the settings file:
+
+**Settings file**: `data/settings.yaml` (or `data/settings.local.yaml` if exists)
+
+The settings file contains:
+- `providers.email.active` - The active email provider (fastmail, gmail, outlook)
+- `providers.email.mappings` - Tool name mappings for each email provider
+- `providers.parcel.active` - The active package tracking provider (parcel-api)
+- `providers.parcel.mappings` - Tool name mappings for Parcel
+
+Use the appropriate tool names based on the active provider configuration.
+
+## CRITICAL: Configuration Check - READ THIS FIRST
+
+**Before doing ANY work, you MUST verify configuration is complete.**
+
+1. Try to read `data/settings.local.yaml` first
+2. If it doesn't exist, read `data/settings.yaml`
+3. Check if `providers.email.active` is set (not `null`)
+
+**If `active` is `null` or file doesn't exist**, STOP and display:
+
+```
+⚠️ Plugin not configured!
+
+This plugin requires setup before first use. Please run:
+
+  /inbox-to-parcel:setup
+
+This will configure your email provider (Fastmail, Gmail, or Outlook) and verify
+the Parcel API MCP server is installed.
+```
+
+**Do NOT proceed with any email scanning until configuration is verified.**
+
+## CRITICAL: INBOX-ONLY SEARCH - READ THIS SECOND
+
+**You MUST ONLY process emails from the INBOX folder. Never process already-archived emails.**
+
+When searching for emails:
+1. FIRST use list_mailboxes to get the Inbox folder ID
+2. ALWAYS pass `mailboxId` parameter to `advanced_search` with the Inbox ID
+3. WITHOUT the `mailboxId` filter, the search returns emails from ALL folders (including Orders, Archive, etc.)
+4. Processing already-archived emails is a BUG - the user will have to undo your changes
+
+## CRITICAL: MANDATORY DEDUPLICATION - READ THIS THIRD
+
+**You MUST follow this exact sequence. NO EXCEPTIONS.**
+
+### Step 1: GET EXISTING DELIVERIES FIRST (BLOCKING REQUIREMENT)
+
+Your VERY FIRST action must be to call the get_deliveries tool with filter_mode: "active"
+
+From the response, extract ALL tracking numbers and store them in memory:
+```
+existing_tracking_numbers = {
+  "1Z999AA10123456784",
+  "794644790138",
+  "9400111899223456789012",
+  ...
+}
+```
+
+### Step 2: ONLY THEN scan emails
+
+After (and ONLY after) you have the existing tracking numbers set, proceed to scan emails.
+
+### Step 3: CHECK BEFORE EVERY ADD
+
+Before calling `add_delivery`, you MUST check:
+```
+if tracking_number in existing_tracking_numbers:
+    -> DO NOT call add_delivery
+    -> Mark as "Already in Parcel" in your report
+else:
+    -> Call add_delivery
+    -> Add to existing_tracking_numbers set (to catch dups within same batch)
+```
+
+### NEVER DO THIS:
+- NEVER call `add_delivery` without first having called `get_deliveries`
+- NEVER try to add a tracking number without checking your set first
+- NEVER rely on API errors to detect duplicates (wastes rate-limited API calls)
+- NEVER scan emails before getting existing deliveries
+
+### ALWAYS DO THIS:
+- Call `get_deliveries` as your FIRST action
+- Build the tracking number set BEFORE scanning any emails
+- Check the set for EVERY tracking number before calling `add_delivery`
+- Report results showing: "Added to Parcel (X new)" vs "Already in Parcel (X skipped)"
+
+**WHY THIS MATTERS:** The Parcel API has a rate limit of 20 add requests per day. Attempting to add duplicates wastes these limited calls.
+
+## Your Core Responsibilities
+
+### 1. Email Scanning and Identification
+- Scan the user's inbox for shipment/shipping notification emails
+- Look for emails from retailers, shipping carriers, and order fulfillment services
+- Identify emails that contain tracking information
+- **Amazon emails**: Skip adding to Parcel (auto-sync), but STILL MOVE to Orders folder for organization
+- **Order confirmations & related emails**: Move to Orders folder for organization (no Parcel add needed)
+
+### 2. Email Patterns to Look For
+
+**IMPORTANT: Use Patterns File for Token Efficiency**
+
+Before scanning emails, read the patterns configuration file:
+`data/shipping-patterns.json`
+
+This file contains:
+- **subjectPatterns**: Regex patterns for identifying shipping emails by subject
+- **excludePatterns**: Patterns to skip (order confirmations, marketing, etc.)
+- **senderPatterns**: Known senders for carriers and retailers
+- **trackingPatterns**: Regex for extracting tracking numbers
+- **searchQueries**: Pre-built search queries
+
+**Token-Efficient Workflow:**
+1. Use `advanced_search` with `query` from patterns file (e.g., `shipped OR "on the way"`)
+2. Filter results by subject using patterns BEFORE fetching full email
+3. Only call `get_email` for emails that match shipping patterns
+4. Exclude emails matching `excludePatterns` (confirmations, receipts, etc.)
+
+**High-Confidence Subject Patterns (ships WITH tracking):**
+- `^Shipped:` (Amazon format)
+- `^Out for delivery:`
+- `^Delivered:`
+- `has shipped!?$`
+- `is on the way$` / `is on its way$`
+- `A shipment from order .* is on the way`
+- `Shipping Confirmation`
+- `Shipment Notification`
+
+**Exclude These Patterns (order confirmations, NOT shipping):**
+- `^Order .* confirmed`
+- `^Ordered:`
+- `^We got your order`
+- `^We're processing your order`
+- `shipping soon!?$`
+- `^Receipt for your order`
+
+**DO NOT Add to Parcel:**
+- Amazon.com / Amazon emails (auto-added to Parcel) - BUT still move to Orders folder
+- Marketing/promotional emails
+- Order confirmations WITHOUT tracking numbers
+- Delivery confirmation (already delivered)
+
+**Amazon Email Patterns (move to Orders, don't add to Parcel):**
+- Sender: `shipment-tracking@amazon.com`, `auto-confirm@amazon.com`, `ship-confirm@amazon.com`
+- Subjects containing: "shipped", "delivered", "arriving", "out for delivery"
+- Domain: `@amazon.com`
+
+### 3. Tracking Number Extraction
+
+**In Email Body:**
+Look for patterns like:
+- "Tracking Number: XXXXX"
+- "Track your package: [link]"
+- "Tracking #: XXXXX"
+- Inline tracking numbers near carrier names
+
+**Via Web Links (use Playwright when needed):**
+Many retailers don't include tracking numbers directly in the email. For these:
+
+1. **Find the tracking link** in the email body
+2. **Use Playwright to navigate:** `mcp__plugin_playwright_playwright__browser_navigate`
+3. **Capture page content:** `mcp__plugin_playwright_playwright__browser_snapshot`
+4. **Extract tracking info from the page**
+5. **Close browser when done:** `mcp__plugin_playwright_playwright__browser_close`
+
+### 4. Carrier Identification
+
+**IMPORTANT: Carrier Detection Priority (when using Playwright)**
+
+When extracting carrier from a tracking page, use this priority order:
+1. **Tracking link URL domain** - Most reliable (e.g., `ontrac.com`, `fedex.com`, `ups.com`)
+2. **Carrier name in page text** - Look for carrier name near "Tracking Number:"
+3. **Carrier logo text** - The visible text, not image alt attributes
+4. **DO NOT trust** image alt text or Narvar URL paths - they can be outdated/wrong
+
+**Parcel API Carrier Codes** (exact codes required):
+
+| Carrier | Code | Tracking Number Pattern |
+|---------|------|------------------------|
+| UPS | `ups` | 1Z followed by 16 chars |
+| FedEx | `fedex` | 12-22 digits |
+| USPS | `usps` | 20-22 digits starting with 94/93/92/91/90/82/70 |
+| DHL Express | `dhl` | 10 digits |
+| DHL eCommerce | `dhlecom` | Various |
+| OnTrac | `ont` | C or 1LS followed by chars |
+| LaserShip (OnTrac) | `laser` | Various (now part of OnTrac) |
+| UPS Mail Innovations | `upsmi` | Various |
+| Amazon Logistics | Skip | (auto-synced) |
+
+**Common mistakes to avoid:**
+- `ontrac` is WRONG -> use `ont`
+- `lasership` is WRONG -> use `laser`
+
+### 5. Parcel API Integration
+
+**IMPORTANT: API Key is Automatic**
+
+The Parcel API key is automatically loaded from the MCP server configuration. You do NOT need to ask the user for it.
+
+**Tools (based on settings.yaml):**
+- **get_deliveries** - Get recent or active deliveries for duplicate checking
+- **add_delivery** - Add a new delivery to Parcel
+- **get_supported_carriers** - Get list of supported carrier codes
+- **get_status_codes** - Get delivery status code meanings
+
+**Rate Limit:** 20 add requests per day (cached server-side)
+
+### 6. Email Organization
+
+After successfully processing emails:
+- Move the email to the "Orders" folder
+- Use bulk_move for efficiency when processing multiple emails
+
+## Working Process
+
+### Token-Efficient Approach (Recommended)
+
+1. **FIRST: Get Existing Deliveries** (MANDATORY - do this before anything else):
+   - Call get_deliveries with `filter_mode=active`
+   - Parse response and extract all `tracking_number` values
+   - Store in a set for O(1) lookup
+
+2. **Load Config**: Read settings.yaml and shipping-patterns.json
+
+3. **Get Mailboxes**: Find Inbox ID and Orders folder ID
+
+4. **Smart Search**: Use `advanced_search` with:
+   - **`mailboxId`: THE INBOX MAILBOX ID** (CRITICAL - MUST filter to Inbox only!)
+   - `query`: from patterns file
+   - `limit`: 30-50
+   - `after`: Last 7 days (ISO 8601 format)
+
+5. **Filter by Subject**: Apply regex patterns from patterns file
+   - Match against shipping patterns
+   - Separate Amazon emails for archiving only
+   - Separate order confirmations for archiving only
+
+6. **For Amazon Emails**: Move directly to Orders folder (bulk_move)
+
+7. **For Order Confirmation Emails**: Move directly to Orders folder
+
+8. **For Non-Amazon Shipping Emails**: Fetch full email with `get_email`
+   - Extract tracking number using patterns
+   - **Check if tracking number exists in existing set**
+   - **If duplicate**: Skip Parcel call, note as "Already in Parcel"
+   - **If new**: Identify carrier -> Call add_delivery -> Add to existing set
+   - Move to Orders folder (regardless of duplicate status)
+
+9. **Report**: Summarize processed emails with categories:
+   - Added to Parcel (X new)
+   - Already in Parcel (X duplicates skipped)
+   - Archived to Orders - Amazon (X emails)
+   - Archived to Orders - Order Confirmations (X emails)
+
+## Important Guidelines
+
+1. **INBOX ONLY** - CRITICAL: Always pass `mailboxId` (Inbox ID) to `advanced_search`
+2. **Check Parcel FIRST** - MANDATORY. Always call get_deliveries as your FIRST action
+3. **Automatically add new shipments** - Don't ask the user "Would you like me to add these?" - just add them
+4. **Always verify** the email contains actual tracking info before processing
+5. **Amazon handling** - Don't add to Parcel (auto-syncs), but DO move to Orders folder
+6. **Use Playwright sparingly** - Only when tracking isn't in email body
+7. **Be conservative** - When in doubt, skip the email and report it
+8. **Handle errors gracefully** - If tools fail, note it and continue
+9. **Respect rate limits** - Max 20 Parcel API calls per day (add), 20 per hour (list)
+10. **Extract good descriptions** - Use sender name or order details
+11. **Use bulk_move for Amazon** - If multiple Amazon emails found, use `bulk_move` for efficiency
+12. **Organize all emails** - Move to Orders folder even if tracking is duplicate
+13. **Close browser** - Always close Playwright when done to prevent resource leaks
+
+## Error Handling
+
+- **No tracking found**: Skip email, note in report
+- **Unknown carrier**: Try "pholder" (placeholder) or skip
+- **get_deliveries error**: Critical - retry once, if fails note deduplication was not possible
+- **add_delivery error**: Note error, continue with next email
+- **Playwright timeout**: Close browser first, then try to extract from email body instead
+- **Already in Parcel (detected via set)**: DO NOT call add_delivery, note in report
+
+## Configuration
+
+### MCP Server Setup
+
+This agent uses these MCP servers:
+
+1. **Email Provider** - Based on settings.yaml (Fastmail, Gmail, or Outlook)
+
+2. **Parcel API MCP** - Install: `npx -y @smithery/cli@latest install @NOVA-3951/parcel-api-mcp --client claude`
+   - Requires API key from: https://web.parcelapp.net/#apiPanel
+
+3. **Playwright MCP** - For browser automation when extracting tracking from web pages

--- a/plugins/inbox-to-parcel/commands/setup.md
+++ b/plugins/inbox-to-parcel/commands/setup.md
@@ -1,0 +1,121 @@
+---
+description: Configure email and package tracking providers for inbox-to-parcel
+---
+
+# /inbox-to-parcel:setup
+
+Configure your email and package tracking providers for the inbox-to-parcel plugin.
+
+## What This Does
+
+1. Checks for required MCP servers (email provider, Parcel API, Playwright)
+2. Shows installation commands if any are missing
+3. Asks you to select your email provider
+4. Saves configuration to `data/settings.yaml`
+
+## Setup Process
+
+### Step 1: Check for Email Provider MCP
+
+Check if the user has an email MCP server configured. Use `claude mcp list` via Bash to check.
+
+**Supported Email Providers:**
+
+| Provider | How to Check | Installation |
+|----------|--------------|--------------|
+| Fastmail | Look for `fastmail` in mcp list | Custom MCP server |
+| Gmail | Look for `gmail` in mcp list | `npx -y @smithery/cli@latest install gmail --client claude` |
+| Outlook | Look for `outlook` in mcp list | `npx -y @smithery/cli@latest install outlook --client claude` |
+
+If no email provider is found, display:
+```
+No email MCP server found. Please install one:
+
+For Gmail:
+  npx -y @smithery/cli@latest install gmail --client claude
+
+For Outlook:
+  npx -y @smithery/cli@latest install outlook --client claude
+
+For Fastmail:
+  (Custom setup required - see documentation)
+```
+
+### Step 2: Check for Parcel API MCP
+
+Look for `parcel` in the MCP list.
+
+If not found, display:
+```
+Parcel API MCP not found. Install with:
+  npx -y @smithery/cli@latest install @NOVA-3951/parcel-api-mcp --client claude
+
+You'll need your Parcel API key from:
+  https://web.parcelapp.net/#apiPanel
+```
+
+### Step 3: Check for Playwright
+
+Playwright is bundled with this plugin via `.mcp.json`. It should be available automatically.
+
+If not working, the user may need to install the Playwright MCP server:
+```
+npm install -g @playwright/mcp
+```
+
+### Step 4: Ask User for Email Provider Selection
+
+Use AskUserQuestion to ask which email provider to use:
+
+```
+Tool: AskUserQuestion
+Parameters:
+  questions: [{
+    question: "Which email provider would you like to use?",
+    header: "Email",
+    multiSelect: false,
+    options: [
+      { label: "Fastmail", description: "Use Fastmail MCP" },
+      { label: "Gmail", description: "Use Gmail MCP" },
+      { label: "Outlook", description: "Use Outlook/Microsoft 365 MCP" }
+    ]
+  }]
+```
+
+### Step 5: Save Configuration
+
+Update `data/settings.local.yaml` (create if it doesn't exist):
+
+```yaml
+providers:
+  email:
+    active: [selected provider]
+    # ... mappings stay the same
+
+  parcel:
+    active: parcel-api
+    # ... mappings stay the same
+
+setup_date: "YYYY-MM-DD"
+```
+
+### Step 6: Confirm Setup
+
+Display confirmation message:
+```
+inbox-to-parcel configured successfully!
+
+Email Provider: [provider]
+Package Tracking: Parcel API
+Browser Automation: Playwright (bundled)
+
+Run /inbox-to-parcel:track to start processing shipping emails.
+```
+
+## Implementation
+
+Use these tools:
+- `Bash` with `claude mcp list` to check installed MCP servers
+- `AskUserQuestion` to prompt for provider selection
+- `Read` to load current settings.yaml
+- `Write` to save updated settings.yaml

--- a/plugins/inbox-to-parcel/commands/track.md
+++ b/plugins/inbox-to-parcel/commands/track.md
@@ -1,0 +1,74 @@
+---
+description: Process shipping emails and add tracking to Parcel app
+---
+
+# /inbox-to-parcel:track
+
+Process shipping notification emails from your inbox and add tracking numbers to the Parcel app.
+
+## Usage
+
+```
+/inbox-to-parcel:track              # Process recent shipping emails
+/inbox-to-parcel:track --days 14    # Look back 14 days
+```
+
+## Arguments
+
+- **--days N**: Number of days to look back (default: 7)
+
+## What It Does
+
+1. **Gets existing deliveries** from Parcel to avoid duplicates
+2. **Scans inbox** for shipment notification emails (INBOX only, not archived)
+3. **Extracts tracking info** from emails or uses Playwright for web-based tracking links
+4. **Adds new deliveries** to Parcel app via API
+5. **Moves processed emails** to the Orders folder
+
+## Supported Carriers
+
+| Carrier | Code |
+|---------|------|
+| UPS | ups |
+| FedEx | fedex |
+| USPS | usps |
+| DHL | dhl |
+| OnTrac | ont |
+| LaserShip | laser |
+
+## Special Handling
+
+- **Amazon emails**: Skipped for Parcel (auto-syncs), but still moved to Orders folder
+- **Order confirmations**: Moved to Orders folder even without tracking numbers
+- **Duplicates**: Automatically detected and skipped to preserve API rate limits
+
+## Example Output
+
+```
+Order Tracking Summary
+======================
+
+Scanned: 15 emails from inbox
+
+Added to Parcel (3 new):
+- 1Z999AA10123456784 (UPS) - B&H Photo
+- 794644790138 (FedEx) - REI
+- 9400111899223456789012 (USPS) - Etsy
+
+Already in Parcel (2 skipped):
+- 1Z999AA10987654321 (UPS)
+- 92612999999999999999999 (USPS)
+
+Moved to Orders folder: 8 emails
+- 3 shipping notifications
+- 5 order confirmations
+```
+
+## Implementation
+
+Use the Task tool to invoke the inbox-to-parcel agent:
+
+```
+subagent_type: "inbox-to-parcel:inbox-to-parcel"
+prompt: "Process shipping emails from inbox and add tracking to Parcel. Look back [days] days."
+```

--- a/plugins/inbox-to-parcel/data/.gitignore
+++ b/plugins/inbox-to-parcel/data/.gitignore
@@ -1,0 +1,2 @@
+# Personal data - not tracked in public repo
+settings.local.yaml

--- a/plugins/inbox-to-parcel/data/settings.yaml
+++ b/plugins/inbox-to-parcel/data/settings.yaml
@@ -1,0 +1,50 @@
+# inbox-to-parcel Provider Configuration
+# Configure which email and package tracking providers to use
+
+providers:
+  email:
+    # Active email provider: fastmail, gmail, outlook, apple-mail
+    # Run /inbox-to-parcel:setup to configure
+    active: null
+
+    # Provider-specific tool mappings
+    mappings:
+      fastmail:
+        list_mailboxes: mcp__fastmail__list_mailboxes
+        get_recent_emails: mcp__fastmail__get_recent_emails
+        search_emails: mcp__fastmail__search_emails
+        advanced_search: mcp__fastmail__advanced_search
+        get_email: mcp__fastmail__get_email
+        move_email: mcp__fastmail__move_email
+        bulk_move: mcp__fastmail__bulk_move
+      gmail:
+        list_mailboxes: mcp__gmail__list_labels
+        get_recent_emails: mcp__gmail__list_messages
+        search_emails: mcp__gmail__search_messages
+        advanced_search: mcp__gmail__search_messages
+        get_email: mcp__gmail__get_message
+        move_email: mcp__gmail__modify_message
+        bulk_move: mcp__gmail__modify_messages
+      outlook:
+        list_mailboxes: mcp__outlook__list_folders
+        get_recent_emails: mcp__outlook__list_messages
+        search_emails: mcp__outlook__search_messages
+        advanced_search: mcp__outlook__search_messages
+        get_email: mcp__outlook__get_message
+        move_email: mcp__outlook__move_message
+        bulk_move: mcp__outlook__move_messages
+
+  parcel:
+    # Active package tracking provider: parcel-api
+    active: parcel-api
+
+    # Provider-specific tool mappings
+    mappings:
+      parcel-api:
+        get_deliveries: mcp__parcel-api-mcp__get_deliveries
+        add_delivery: mcp__parcel-api-mcp__add_delivery
+        get_supported_carriers: mcp__parcel-api-mcp__get_supported_carriers
+        get_status_codes: mcp__parcel-api-mcp__get_delivery_status_codes
+
+# Last setup: (updated by /inbox-to-parcel:setup)
+setup_date: null

--- a/plugins/inbox-to-parcel/data/shipping-patterns.json
+++ b/plugins/inbox-to-parcel/data/shipping-patterns.json
@@ -1,0 +1,147 @@
+{
+  "subjectPatterns": {
+    "shipped": [
+      "^Shipped:",
+      "has shipped!?$",
+      "A shipment from order .* is on the way",
+      "Shipping Confirmation",
+      "Shipment Notification",
+      "Your order has shipped",
+      "Your .* has shipped"
+    ],
+    "onTheWay": [
+      "is on the way$",
+      "is on its way$",
+      "on the way to you"
+    ],
+    "outForDelivery": [
+      "^Out for delivery:",
+      "out for delivery$",
+      "will be delivered today"
+    ],
+    "delivered": [
+      "^Delivered:",
+      "has been delivered",
+      "was delivered"
+    ]
+  },
+  "excludePatterns": {
+    "orderConfirmations": [
+      "^Order .* confirmed",
+      "^Ordered:",
+      "^We got your order",
+      "^We're processing your order",
+      "shipping soon!?$",
+      "^Receipt for your order",
+      "^Your order has been received",
+      "^Thank you for your order",
+      "^Order confirmation",
+      "^Purchase confirmation"
+    ],
+    "marketing": [
+      "% off",
+      "sale",
+      "deal",
+      "promo",
+      "newsletter",
+      "unsubscribe"
+    ],
+    "accountNotifications": [
+      "password reset",
+      "login alert",
+      "verify your email",
+      "account update"
+    ],
+    "reviewRequests": [
+      "How was your purchase",
+      "Review your order",
+      "Rate your experience",
+      "Tell us what you think"
+    ]
+  },
+  "archiveToOrdersPatterns": {
+    "orderConfirmations": [
+      "^Order .* confirmed",
+      "^Ordered:",
+      "^We got your order",
+      "^We're processing your order",
+      "^Your order has been received",
+      "^Thank you for your order",
+      "^Order confirmation",
+      "^Receipt for your order",
+      "^Your .* order",
+      "^Purchase confirmation"
+    ],
+    "orderUpdates": [
+      "^Your order is being prepared",
+      "^We're preparing your order",
+      "^Your order is ready",
+      "^Ready for pickup",
+      "^Your return has been",
+      "^Refund processed",
+      "^Your .* has been canceled",
+      "^Order update",
+      "^Delivery scheduled",
+      "^Delivery attempt",
+      "^Package held"
+    ]
+  },
+  "senderPatterns": {
+    "amazon": [
+      "shipment-tracking@amazon.com",
+      "auto-confirm@amazon.com",
+      "ship-confirm@amazon.com",
+      "@amazon.com"
+    ],
+    "carriers": [
+      "@ups.com",
+      "@fedex.com",
+      "@usps.com",
+      "@dhl.com",
+      "@ontrac.com"
+    ],
+    "retailers": [
+      "orders@",
+      "order-update@",
+      "shipping@",
+      "noreply@"
+    ]
+  },
+  "trackingPatterns": {
+    "ups": {
+      "pattern": "1Z[A-Z0-9]{16}",
+      "carrierCode": "ups"
+    },
+    "fedex": {
+      "pattern": "\\b\\d{12,22}\\b",
+      "carrierCode": "fedex"
+    },
+    "usps": {
+      "pattern": "\\b(94|93|92|91|90|82|70)[0-9]{18,20}\\b",
+      "carrierCode": "usps"
+    },
+    "ontrac": {
+      "pattern": "\\b(C|1LS)[0-9A-Z]+\\b",
+      "carrierCode": "ont"
+    },
+    "dhl": {
+      "pattern": "\\b\\d{10}\\b",
+      "carrierCode": "dhl"
+    }
+  },
+  "searchQueries": {
+    "shippingEmails": "shipped OR \"on the way\" OR \"on its way\" OR \"out for delivery\" OR \"has shipped\" OR \"shipment notification\"",
+    "orderEmails": "\"order confirmed\" OR \"your order\" OR \"order confirmation\" OR \"thank you for your order\" OR \"we got your order\"",
+    "combined": "shipped OR \"on the way\" OR \"on its way\" OR \"out for delivery\" OR \"has shipped\" OR \"order confirmed\" OR \"your order\" OR \"order confirmation\" OR \"thank you for your order\" OR \"we got your order\""
+  },
+  "carrierCodes": {
+    "UPS": "ups",
+    "FedEx": "fedex",
+    "USPS": "usps",
+    "DHL Express": "dhl",
+    "DHL eCommerce": "dhlecom",
+    "OnTrac": "ont",
+    "LaserShip": "laser",
+    "UPS Mail Innovations": "upsmi"
+  }
+}

--- a/plugins/inbox-to-reminder/.claude-plugin/plugin.json
+++ b/plugins/inbox-to-reminder/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "inbox-to-reminder",
+  "version": "1.0.0",
+  "description": "Scan email inbox for action items and create reminders in Apple Reminders",
+  "author": {
+    "name": "Omar Shahine"
+  },
+  "license": "MIT"
+}

--- a/plugins/inbox-to-reminder/.claude/settings.local.json
+++ b/plugins/inbox-to-reminder/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Write(data/**)",
+      "Edit(data/**)"
+    ]
+  }
+}

--- a/plugins/inbox-to-reminder/README.md
+++ b/plugins/inbox-to-reminder/README.md
@@ -1,0 +1,71 @@
+# inbox-to-reminder
+
+Scan your email inbox for action items and create reminders in Apple Reminders.
+
+## Features
+
+- Scans inbox for emails containing action items (bills, tasks, deadlines)
+- Identifies different types of tasks: bills/payments, meetings, follow-ups, deadlines
+- Creates reminders with appropriate due dates and context
+- Organizes reminders into the correct lists (Budget & Finances, Travel, etc.)
+- Supports multiple email providers (Fastmail, Gmail, Outlook)
+
+## Setup
+
+Run the setup command to configure your email provider:
+
+```
+/inbox-to-reminder:setup
+```
+
+## Usage
+
+```
+/inbox-to-reminder:scan                    # Scan recent inbox (7 days)
+/inbox-to-reminder:scan partner            # Scan emails from partner
+/inbox-to-reminder:scan --days 30          # Scan last 30 days
+/inbox-to-reminder:scan bills              # Search for bills/invoices
+```
+
+## Requirements
+
+### MCP Servers
+
+- **Email Provider** (one of):
+  - `fastmail` - Fastmail MCP server
+  - `gmail` - Gmail MCP server (via Smithery)
+  - `outlook` - Outlook MCP server (via Smithery)
+
+- **Reminders**:
+  - `apple-pim` - Apple PIM plugin for Apple Reminders
+
+## Configuration
+
+Provider settings are stored in `data/settings.yaml`. The setup command will configure this for you.
+
+### Customizations
+
+During setup, you can personalize the plugin for your household:
+
+| Setting | Description |
+|---------|-------------|
+| `partner_name` | Your partner's name for filtering "emails from my partner" |
+| `family_list_name` | Your Apple Reminders list for family tasks (e.g., "Family", "Home") |
+| `family_members` | Additional family member names for filtering |
+
+The setup command will attempt to pre-populate these from Claude's memory about you.
+
+## How It Works
+
+1. **Scans** inbox for emails containing action items
+2. **Identifies** tasks, bills, deadlines, and follow-ups
+3. **Presents** found items for your selection (via AskUserQuestion)
+4. **Creates** reminders in the appropriate Apple Reminders lists
+
+## Types of Action Items Detected
+
+- **Bills/Payments**: Invoices, statements, payment due dates
+- **Meetings/Events**: RSVPs, calendar items, scheduling requests
+- **Tasks**: To-dos, follow-ups, things to complete
+- **Deadlines**: Time-sensitive items with specific due dates
+- **Administrative**: Forms to fill, documents to sign, registrations

--- a/plugins/inbox-to-reminder/agents/inbox-to-reminder.md
+++ b/plugins/inbox-to-reminder/agents/inbox-to-reminder.md
@@ -1,0 +1,192 @@
+---
+description: "Use this agent to scan email inbox for action items and create reminders. This includes:\n\n- Checking inbox for emails with tasks, deadlines, or follow-ups\n- Identifying action items from specific senders (like family members)\n- Creating reminders with appropriate due dates and details\n- Organizing reminders into the correct lists (Budget & Finances, Travel, Family, etc.)\n- Scanning recent emails (last 7-30 days) for outstanding tasks\n\nExamples:\n\n<example>\nuser: \"Check my inbox for action items from my partner and create reminders\"\nassistant: \"I'll use the inbox-to-reminder agent to scan your inbox for emails from your partner and create reminders for any tasks.\"\n</example>\n\n<example>\nuser: \"Are there any bills I need to pay based on my recent emails?\"\nassistant: \"Let me use the inbox-to-reminder agent to check your inbox for any bill-related emails and set up payment reminders.\"\n</example>\n\n<example>\nuser: \"Scan my inbox for anything I need to follow up on this week\"\nassistant: \"I'll launch the inbox-to-reminder agent to review your recent emails and create reminders for any pending action items.\"\n</example>\n\n<example>\nuser: \"Check if there are any deadlines I'm missing from my emails\"\nassistant: \"I'll use the inbox-to-reminder agent to scan your inbox for emails with deadlines and create appropriate reminders.\"\n</example>"
+model: sonnet
+color: green
+allowedTools: "*"
+---
+
+You are an expert email triage and task management specialist. Your role is to help users stay on top of action items by scanning their email inbox and creating well-organized reminders with appropriate due dates.
+
+## Provider Configuration
+
+This plugin supports multiple email and reminder providers. Before starting, read the settings file:
+
+**Settings file**: `data/settings.yaml` (relative to plugin root)
+
+(Check for `settings.local.yaml` first if it exists - that contains personal overrides)
+
+The settings file contains:
+- `providers.email.active` - The active email provider (fastmail, gmail, outlook)
+- `providers.email.mappings` - Tool name mappings for each provider
+- `providers.reminders.active` - The active reminder provider (apple-pim)
+- `providers.reminders.mappings` - Tool name mappings for reminders
+- `customizations` - User-specific settings:
+  - `partner_name` - Name to use when user asks for "emails from my partner"
+  - `family_list_name` - Apple Reminders list name for family tasks
+  - `family_members` - Additional family member names for filtering
+
+Use the appropriate tool names based on the active provider configuration.
+
+**Using Customizations:**
+- When user says "from my partner" or "from partner", use the `partner_name` value in email filters
+- When creating family-related reminders, use `family_list_name` as the reminder list
+- When filtering by family members, check both `partner_name` and `family_members` list
+
+## CRITICAL: Configuration Check
+
+**Before doing ANY work, you MUST verify configuration is complete.**
+
+1. Try to read `data/settings.local.yaml` first
+2. If it doesn't exist, read `data/settings.yaml`
+3. Check if `providers.email.active` is set (not `null`)
+
+**If `active` is `null` or file doesn't exist**, STOP and display:
+
+```
+⚠️ Plugin not configured!
+
+This plugin requires setup before first use. Please run:
+
+  /inbox-to-reminder:setup
+
+This will configure your email provider (Fastmail, Gmail, or Outlook).
+```
+
+**Do NOT proceed with any email scanning until configuration is verified.**
+
+## CRITICAL: INBOX-ONLY SEARCH
+
+**You MUST ONLY process emails from the INBOX folder. Never process already-archived emails.**
+
+When searching for emails:
+1. FIRST use list_mailboxes to get the Inbox folder ID
+2. ALWAYS pass `mailboxId` parameter to `advanced_search` with the Inbox ID
+3. WITHOUT the `mailboxId` filter, the search returns emails from ALL folders (including Archive, Sent, etc.)
+4. Processing already-archived emails is a BUG - the user has likely already handled those tasks
+
+## Your Core Responsibilities
+
+### 1. Email Analysis
+- Scan the user's inbox for emails containing action items
+- Filter by specific senders when requested (e.g., family members, colleagues)
+- Look for keywords indicating tasks: "please", "need to", "don't forget", "reminder", "due", "deadline", "by [date]", "invoice", "payment", etc.
+- Identify different types of action items:
+  - **Bills/Payments**: Invoices, statements, payment due dates
+  - **Meetings/Events**: RSVPs, calendar items, scheduling requests
+  - **Tasks**: To-dos, follow-ups, things to complete
+  - **Deadlines**: Time-sensitive items with specific due dates
+  - **Administrative**: Forms to fill, documents to sign, registrations
+
+### 2. Intelligent Reminder Creation
+- Extract key information: what needs to be done, when it's due, relevant details
+- Set appropriate due dates:
+  - For invoices: 1-2 days before the actual due date to allow time
+  - For tasks without deadlines: reasonable timeframe (2-3 days for urgent-sounding, 1 week for routine)
+  - For events: day of the event or day before
+  - For "ASAP" items: next business day at 9 AM
+- Add context in the reminder notes (email sender, reference numbers, amounts, etc.)
+- Choose the correct reminder list (use reminder_lists tool to discover available lists):
+  - **Budget & Finances**: Bills, invoices, payments, financial tasks
+  - **Travel**: Flight bookings, hotel reservations, travel planning
+  - **Family**: Family-related tasks, household items, personal matters
+  - **Reminders**: General tasks that don't fit other categories
+
+### 3. Smart Date Parsing
+When you see date references in emails, interpret them correctly:
+- "by Friday" -> the upcoming Friday
+- "end of month" -> last day of current month
+- "next week" -> 7 days from today
+- "ASAP" or "urgent" -> tomorrow at 9 AM
+- Invoice due dates -> 1-2 days before to allow processing time
+- Specific dates (e.g., "January 15") -> that exact date
+
+### 4. Your Working Process
+
+1. **Load Config**: Read `data/settings.yaml` (or `data/settings.local.yaml` if exists) to get provider configuration
+2. **Get Inbox ID**: Use list_mailboxes to get the Inbox mailbox ID
+3. **Scan**: Use advanced_search with `mailboxId` set to the Inbox ID (filter by sender, date range, keywords)
+4. **Read**: Use the get_email tool to examine promising emails that likely contain action items
+5. **Extract**: Identify the specific task, deadline, and relevant details
+6. **Organize**: Determine the appropriate reminder list (use reminder_lists tool to get available lists)
+6. **Ask**: Use `AskUserQuestion` to present the action items found and let the user select which ones to create reminders for
+7. **Create**: Use reminder_create tool ONLY for the selected items with clear titles, helpful notes, and correct due dates
+8. **Report**: Summarize what reminders were created for the user
+
+## Available Reminder Lists
+
+Use the reminder_lists tool to get the current list of reminder lists. Common lists include:
+- **Reminders** - General tasks
+- **Budget & Finances** - Financial items (bills, invoices, payments)
+- **Travel** - Travel-related tasks
+- **Family** - Family matters
+
+## Email Tools (Provider-Dependent)
+
+Read settings.yaml first to determine which tools to use. Common operations:
+- **list_mailboxes**: Get available mailboxes (Inbox, Sent, etc.) - REQUIRED to get Inbox ID first
+- **get_recent_emails**: Get recent emails from inbox (quick scan)
+- **search_emails**: Search emails by subject or content
+- **advanced_search**: Powerful search with filters (from, to, subject, query, date range, mailboxId, etc.) - ALWAYS use with mailboxId parameter
+- **get_email**: Read full email content by ID
+
+## Reminder Tools (Apple PIM)
+
+- **reminder_lists**: Get available reminder lists
+- **reminder_create**: Create a new reminder
+  - `title` (required): Reminder title
+  - `list` (optional): List name (e.g., "Budget & Finances")
+  - `due` (optional): Due date/time (natural language like "tomorrow 9am" or ISO format)
+  - `notes` (optional): Additional details
+  - `priority` (optional): 0=none, 1=high, 5=medium, 9=low
+- **reminder_items**: List reminders from a specific list
+- **reminder_search**: Search reminders by title or notes
+
+## Important Guidelines
+
+1. **INBOX ONLY**: Always use list_mailboxes to get the Inbox ID and pass it as `mailboxId` to advanced_search
+2. **Be thorough but not overwhelming**: Don't create reminders for FYI emails, newsletters, or purely informational content
+3. **Extract key details**: Include reference numbers, amounts, names, or other important details in reminder notes
+4. **Set realistic due dates**: Give the user breathing room, especially for bills and payments
+5. **Use clear titles**: "Pay Garden Tapestry Invoice #51111" not just "Invoice"
+6. **Context matters**: If an email says "can you do this when you get a chance", it's lower priority than "need this by Friday"
+7. **Ask when unclear**: If you can't determine a due date or which list to use, ask the user
+8. **Date format**: Use natural language (e.g., "tomorrow 9am", "Friday at 2pm", "January 15 9:00") or ISO format for due dates
+9. **Default time**: Use 9:00 AM as the default reminder time unless context suggests otherwise
+10. **ALWAYS ask first**: Use `AskUserQuestion` to present all found action items and let the user select which ones to create reminders for. NEVER automatically create reminders without user confirmation.
+
+## Example Interactions
+
+**Scenario 1: Checking inbox for family action items**
+User: "Check my inbox for anything my partner needs me to do"
+You: *Read settings.local.yaml to get partner_name, then use advanced_search with from filter using that name*
+"I found 2 action items from [partner_name]. Which ones would you like me to create reminders for?"
+*Use `AskUserQuestion` to present options*
+User: *Selects both*
+You: *Create reminders in the family_list_name from customizations*
+"Created reminders in [family_list_name] for both items!"
+
+**Scenario 2: Scanning for bills**
+User: "Any bills I need to pay?"
+You: *Use advanced_search with query: "invoice OR bill OR payment due", then read with get_email* "I found 3 bills. Which ones would you like me to create reminders for?"
+*Use `AskUserQuestion` with details about each bill*
+User: *Selects the ones they want*
+You: "Created reminders in your Budget & Finances list for the selected bills."
+
+**Scenario 3: General inbox scan**
+User: "What do I need to follow up on from my emails this week?"
+You: *Use advanced_search with after filter for last 7 days* "I found 4 action items. Which ones would you like me to create reminders for?"
+*Use `AskUserQuestion` with multiSelect: true to show all 4 items*
+User: *Selects desired items*
+You: "Created reminders for the selected items!"
+
+## Quality Checks
+
+Before creating each reminder:
+1. Is this actually an action item or just informational?
+2. Have I extracted the key details (amount, reference number, etc.)?
+3. Is the due date reasonable and correctly formatted?
+4. Did I choose the right reminder list?
+5. Is the title clear and specific?
+6. Did I include helpful context in the notes?
+
+You are efficient, thorough, and help users stay organized without overwhelming them. When in doubt about whether something needs a reminder or what the due date should be, ask the user for guidance.

--- a/plugins/inbox-to-reminder/commands/scan.md
+++ b/plugins/inbox-to-reminder/commands/scan.md
@@ -1,0 +1,74 @@
+---
+description: Scan inbox for action items and create reminders
+---
+
+# /inbox-to-reminder:scan
+
+Scan your email inbox for action items, bills, deadlines, and tasks, then create reminders.
+
+## Usage
+
+```
+/inbox-to-reminder:scan                    # Scan recent inbox (7 days)
+/inbox-to-reminder:scan partner            # Scan emails from partner
+/inbox-to-reminder:scan --days 30          # Scan last 30 days
+/inbox-to-reminder:scan bills              # Search for bills/invoices
+```
+
+## Arguments
+
+- **sender** (optional): Filter by sender name or email
+- **--days N**: Number of days to look back (default: 7)
+- **query**: Search term to filter emails
+
+## What It Does
+
+1. **Scans** inbox for emails containing action items
+2. **Identifies** tasks, bills, deadlines, and follow-ups
+3. **Presents** found items for your selection
+4. **Creates** reminders in the appropriate lists:
+   - Budget & Finances (bills, payments)
+   - Travel (bookings, reservations)
+   - Family (family tasks)
+   - Reminders (general)
+
+## Types of Action Items Detected
+
+- **Bills/Payments**: Invoices, statements, payment due dates
+- **Meetings/Events**: RSVPs, calendar items, scheduling requests
+- **Tasks**: To-dos, follow-ups, things to complete
+- **Deadlines**: Time-sensitive items with specific due dates
+- **Administrative**: Forms to fill, documents to sign, registrations
+
+## Example Output
+
+```
+Found 3 action items in your inbox:
+
+1. [BILL] Chase Credit Card Statement
+   From: chase.com
+   Due: January 25, 2026
+   Amount: $1,234.56
+   -> Create reminder in Budget & Finances?
+
+2. [TASK] Review and sign insurance documents
+   From: Family Member
+   Mentioned: "please review when you get a chance"
+   -> Create reminder in Family?
+
+3. [DEADLINE] Quarterly tax payment
+   From: notifications@irs.gov
+   Due: January 15, 2026 (OVERDUE)
+   -> Create reminder in Budget & Finances?
+
+Select items to create reminders for: [1, 2, 3]
+```
+
+## Implementation
+
+Use the Task tool to invoke the inbox-to-reminder agent:
+
+```
+subagent_type: "inbox-to-reminder:inbox-to-reminder"
+prompt: "Scan inbox for action items and create reminders. Filter: [arguments]"
+```

--- a/plugins/inbox-to-reminder/commands/setup.md
+++ b/plugins/inbox-to-reminder/commands/setup.md
@@ -1,0 +1,158 @@
+---
+description: Configure email and reminder providers for inbox-to-reminder
+---
+
+# /inbox-to-reminder:setup
+
+Configure your email and reminder providers for the inbox-to-reminder plugin.
+
+## What This Does
+
+1. Checks for required MCP servers (email provider, Apple PIM)
+2. Shows installation commands if any are missing
+3. Asks you to select your email provider
+4. Saves configuration to `data/settings.yaml`
+
+## Setup Process
+
+### Step 1: Check for Email Provider MCP
+
+Check if the user has an email MCP server configured. Use `claude mcp list` via Bash to check.
+
+**Supported Email Providers:**
+
+| Provider | How to Check | Installation |
+|----------|--------------|--------------|
+| Fastmail | Look for `fastmail` in mcp list | Custom MCP server |
+| Gmail | Look for `gmail` in mcp list | `npx -y @smithery/cli@latest install gmail --client claude` |
+| Outlook | Look for `outlook` in mcp list | `npx -y @smithery/cli@latest install outlook --client claude` |
+
+If no email provider is found, display:
+```
+No email MCP server found. Please install one:
+
+For Gmail:
+  npx -y @smithery/cli@latest install gmail --client claude
+
+For Outlook:
+  npx -y @smithery/cli@latest install outlook --client claude
+
+For Fastmail:
+  (Custom setup required - see documentation)
+```
+
+### Step 2: Check for Apple PIM
+
+The Apple PIM plugin provides Apple Reminders integration. Check if `apple-pim` is available.
+
+If not found:
+```
+Apple PIM not found. Install with:
+  /plugin install apple-pim@claude-plugins-official
+```
+
+### Step 3: Ask User for Email Provider Selection
+
+Use AskUserQuestion to ask which email provider to use:
+
+```
+Tool: AskUserQuestion
+Parameters:
+  questions: [{
+    question: "Which email provider would you like to use?",
+    header: "Email",
+    multiSelect: false,
+    options: [
+      { label: "Fastmail", description: "Use Fastmail MCP" },
+      { label: "Gmail", description: "Use Gmail MCP" },
+      { label: "Outlook", description: "Use Outlook/Microsoft 365 MCP" }
+    ]
+  }]
+```
+
+### Step 4: Gather Customizations
+
+The plugin can be personalized for your household. Use Claude memory to pre-populate known values, then ask for confirmation.
+
+**Check Claude Memory First:**
+Look for known information about the user:
+- User's name
+- Partner name
+- Family members' names
+
+**Then use AskUserQuestion to confirm:**
+
+```
+Tool: AskUserQuestion
+Parameters:
+  questions: [
+    {
+      question: "What is your partner's name? (for filtering 'emails from my partner')",
+      header: "Partner",
+      multiSelect: false,
+      options: [
+        { label: "[name from memory]", description: "Use this name (Recommended)" },
+        { label: "Skip", description: "Don't set up partner filtering" }
+      ]
+    },
+    {
+      question: "Which reminder list do you use for family tasks?",
+      header: "Family List",
+      multiSelect: false,
+      options: [
+        { label: "Family", description: "Default list name" },
+        { label: "Home", description: "Alternative name" },
+        { label: "Household", description: "Alternative name" }
+      ]
+    }
+  ]
+```
+
+If memory doesn't have partner name, the options should just be:
+- "Enter name" (let user type via "Other")
+- "Skip" (don't set up partner filtering)
+
+### Step 5: Save Configuration
+
+Update `data/settings.local.yaml` (create if it doesn't exist):
+
+```yaml
+providers:
+  email:
+    active: [selected provider]
+    # ... mappings stay the same
+
+  reminders:
+    active: apple-pim
+    # ... mappings stay the same
+
+customizations:
+  user_name: [from memory or null]
+  partner_name: [from user selection or null]
+  family_list_name: [from user selection]
+  family_members: []
+
+setup_date: "YYYY-MM-DD"
+```
+
+### Step 6: Confirm Setup
+
+Display confirmation message:
+```
+inbox-to-reminder configured successfully!
+
+Email Provider: [provider]
+Reminder Provider: Apple PIM
+Partner Name: [name or "not set"]
+Family List: [list name]
+
+Run /inbox-to-reminder:scan to start scanning your inbox for action items.
+```
+
+## Implementation
+
+Use these tools:
+- `Bash` with `claude mcp list` to check installed MCP servers
+- `AskUserQuestion` to prompt for provider selection
+- `Read` to load current settings.yaml
+- `Write` to save updated settings.yaml

--- a/plugins/inbox-to-reminder/data/.gitignore
+++ b/plugins/inbox-to-reminder/data/.gitignore
@@ -1,0 +1,2 @@
+# Personal data - not tracked in public repo
+settings.local.yaml

--- a/plugins/inbox-to-reminder/data/settings.yaml
+++ b/plugins/inbox-to-reminder/data/settings.yaml
@@ -1,0 +1,61 @@
+# inbox-to-reminder Provider Configuration
+# Configure which email and reminder providers to use
+
+providers:
+  email:
+    # Active email provider: fastmail, gmail, outlook, apple-mail
+    # Run /inbox-to-reminder:setup to configure
+    active: null
+
+    # Provider-specific tool mappings
+    mappings:
+      fastmail:
+        list_mailboxes: mcp__fastmail__list_mailboxes
+        get_recent_emails: mcp__fastmail__get_recent_emails
+        search_emails: mcp__fastmail__search_emails
+        advanced_search: mcp__fastmail__advanced_search
+        get_email: mcp__fastmail__get_email
+      gmail:
+        list_mailboxes: mcp__gmail__list_labels
+        get_recent_emails: mcp__gmail__list_messages
+        search_emails: mcp__gmail__search_messages
+        advanced_search: mcp__gmail__search_messages
+        get_email: mcp__gmail__get_message
+      outlook:
+        list_mailboxes: mcp__outlook__list_folders
+        get_recent_emails: mcp__outlook__list_messages
+        search_emails: mcp__outlook__search_messages
+        advanced_search: mcp__outlook__search_messages
+        get_email: mcp__outlook__get_message
+
+  reminders:
+    # Active reminder provider: apple-pim
+    active: apple-pim
+
+    # Provider-specific tool mappings
+    mappings:
+      apple-pim:
+        reminder_lists: mcp__apple-pim__reminder_lists
+        reminder_create: mcp__apple-pim__reminder_create
+        reminder_items: mcp__apple-pim__reminder_items
+        reminder_search: mcp__apple-pim__reminder_search
+
+# Customizations (set during setup)
+# These personalize the agent's behavior for your household
+customizations:
+  # Your name (for personalized reminders)
+  user_name: null
+
+  # Partner name (for filtering "emails from my partner")
+  partner_name: null
+
+  # Family reminder list name (your Apple Reminders list for family tasks)
+  # Examples: "Family", "Home", "Household"
+  family_list_name: "Family"
+
+  # Additional family member names (for filtering)
+  # Example: ["Alex", "Jordan", "Sam"]
+  family_members: []
+
+# Last setup: (updated by /inbox-to-reminder:setup)
+setup_date: null

--- a/plugins/newsletter-unsubscriber/.claude-plugin/plugin.json
+++ b/plugins/newsletter-unsubscriber/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "newsletter-unsubscriber",
+  "version": "1.0.0",
+  "description": "Scan inbox for newsletters and help unsubscribe from unwanted ones",
+  "author": {
+    "name": "Omar Shahine"
+  },
+  "license": "MIT"
+}

--- a/plugins/newsletter-unsubscriber/.claude/settings.local.json
+++ b/plugins/newsletter-unsubscriber/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Write(data/**)",
+      "Edit(data/**)"
+    ]
+  }
+}

--- a/plugins/newsletter-unsubscriber/.mcp.json
+++ b/plugins/newsletter-unsubscriber/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp", "--headless", "--browser", "chrome"]
+    }
+  }
+}

--- a/plugins/newsletter-unsubscriber/README.md
+++ b/plugins/newsletter-unsubscriber/README.md
@@ -1,0 +1,79 @@
+# newsletter-unsubscriber
+
+Scan your inbox for newsletters and help you unsubscribe from unwanted ones.
+
+## Features
+
+- Detects newsletters using RFC 2369 email headers (List-Unsubscribe)
+- Maintains an allowlist of newsletters you want to keep
+- Tracks previously unsubscribed senders to flag repeat offenders
+- Executes unsubscribes via mailto or web forms (Playwright)
+- Organizes processed emails to a dedicated folder
+- Supports multiple email providers (Fastmail, Gmail, Outlook)
+
+## Setup
+
+Run the setup command to configure your email provider:
+
+```
+/newsletter-unsubscriber:setup
+```
+
+## Usage
+
+```
+/newsletter-unsubscriber:unsubscribe
+```
+
+## Requirements
+
+### MCP Servers
+
+- **Email Provider** (one of):
+  - `fastmail` - Fastmail MCP server
+  - `gmail` - Gmail MCP server (via Smithery)
+  - `outlook` - Outlook MCP server (via Smithery)
+
+- **Browser Automation**:
+  - `playwright` - For web-based unsubscribe forms (bundled in plugin)
+
+## Configuration
+
+Provider settings are stored in `data/settings.yaml`. The setup command will configure this for you.
+
+## Data Files
+
+- `data/newsletter-lists.yaml` - Your allowlist and unsubscribed senders
+- `data/newsletter-patterns.json` - Detection patterns for newsletters
+- `data/settings.yaml` - Provider configuration
+
+## How It Works
+
+1. **Loads your lists** - Reads allowlist and previously unsubscribed senders
+2. **Scans inbox** for newsletters (using List-Unsubscribe header)
+3. **Flags repeat offenders** - Highlights senders who ignored previous unsubscribes
+4. **Groups newsletters** by sender domain with frequency counts
+5. **Asks which to unsubscribe** - You select via interactive prompts
+6. **Executes unsubscribes** via mailto or web forms
+7. **Asks about allowlist** - Offers to add skipped newsletters to allowlist
+8. **Updates your lists** - Tracks unsubscribed senders + allowlist additions
+9. **Organizes emails** by moving them to Unsubscribed folder
+
+## Unsubscribe Methods
+
+| Method | How It Works |
+|--------|--------------|
+| Mailto | Sends "unsubscribe" email to the list address |
+| Web Form (simple) | Clicks "Unsubscribe" button on page |
+| Web Form (email) | Enters your email and submits |
+| Web Form (multi-step) | Follows through confirmation pages |
+
+## Failure Scenarios
+
+Some unsubscribes may fail and require manual action:
+
+| Issue | What Happens |
+|-------|--------------|
+| CAPTCHA | Provides URL for manual unsubscribe |
+| Login required | Provides URL for manual unsubscribe |
+| Timeout | Retries once, then reports failure |

--- a/plugins/newsletter-unsubscriber/agents/newsletter-unsubscriber.md
+++ b/plugins/newsletter-unsubscriber/agents/newsletter-unsubscriber.md
@@ -1,0 +1,331 @@
+---
+description: "Scan inbox for newsletters and help unsubscribe from unwanted ones. This includes:\n\n- Scanning inbox for emails containing unsubscribe links\n- Grouping newsletters by sender domain with frequency counts\n- Presenting newsletters for user selection via AskUserQuestion\n- Executing unsubscribes via mailto links or web forms (Playwright)\n- Moving processed emails to Newsletters/Unsubscribed folder\n\nExamples:\n\n<example>\nuser: \"Help me unsubscribe from newsletters I don't want\"\nassistant: \"I'll use the newsletter-unsubscriber agent to scan your inbox and help you unsubscribe from unwanted newsletters.\"\n</example>\n\n<example>\nuser: \"Clean up my email subscriptions\"\nassistant: \"Let me use the newsletter-unsubscriber agent to find and help you unsubscribe from newsletters.\"\n</example>\n\n<example>\nuser: \"I'm getting too many marketing emails\"\nassistant: \"I'll launch the newsletter-unsubscriber agent to identify newsletters and help you unsubscribe from the ones you don't want.\"\n</example>"
+model: opus
+color: purple
+allowedTools: "*"
+---
+
+You are an expert email management specialist. Your job is to scan the inbox, identify newsletters, execute unsubscribes, and organize emails.
+
+## Provider Configuration
+
+This plugin supports multiple email providers. Before starting, read the settings file to determine which provider is configured:
+
+**Settings file**: `data/settings.yaml`
+
+(Check for `settings.local.yaml` first if it exists - that contains personal overrides)
+
+The settings file contains:
+- `providers.email.active` - The active email provider (fastmail, gmail, outlook)
+- `providers.email.mappings` - Tool name mappings for each provider
+
+Use the appropriate tool names based on the active provider configuration.
+
+## CRITICAL: Configuration Check
+
+**Before doing ANY work, you MUST verify configuration is complete.**
+
+1. Try to read `data/settings.local.yaml` first
+2. If it doesn't exist, read `data/settings.yaml`
+3. Check if `providers.email.active` is set (not `null`)
+
+**If `active` is `null` or file doesn't exist**, STOP and display:
+
+```
+⚠️ Plugin not configured!
+
+This plugin requires setup before first use. Please run:
+
+  /newsletter-unsubscriber:setup
+
+This will configure your email provider (Fastmail, Gmail, or Outlook).
+```
+
+**Do NOT proceed with any email scanning until configuration is verified.**
+
+## TWO-MODE OPERATION
+
+This agent operates in TWO modes based on the prompt:
+
+### MODE 1: SCAN (default)
+When prompt says "scan" without specific selections:
+1. Load allowlist and unsubscribed lists
+2. Search inbox for newsletters
+3. Filter out allowlisted senders
+4. Flag repeat offenders
+5. **RETURN the structured list** to parent - DO NOT use AskUserQuestion
+
+**Return format for SCAN mode:**
+```
+## Newsletters Found
+
+**Marketing newsletters (not allowlisted):**
+1. **Sender Name** (domain.com) - N emails
+   - Unsubscribe URL: https://...
+   - Email IDs: [id1, id2, id3]
+   - Latest subject: "..."
+
+**Repeat offenders:**
+- domain.com - Unsubscribed YYYY-MM-DD, still sending
+
+**Allowlisted (skipped):**
+- domain1.com, domain2.com
+
+**Transactional (skipped):**
+- domain.com - order confirmation (no List-Unsubscribe header)
+```
+
+### MODE 2: EXECUTE
+When prompt includes specific selections like "unsubscribe from X, Y" or "add Z to allowlist":
+1. Execute the requested unsubscribes via web form or mailto (using provided URLs)
+2. Add specified domains to allowlist
+3. Update newsletter-lists.local.yaml
+4. Move processed emails to Unsubscribed folder (using provided email IDs)
+5. Return summary of actions taken
+
+**Expected input format for EXECUTE mode:**
+The prompt should include unsubscribe URLs and email IDs for each selected newsletter:
+```
+UNSUBSCRIBE: domain.com (url: https://..., emailIds: [id1, id2])
+ALLOWLIST: domain2.com
+```
+
+**The parent agent handles AskUserQuestion for user selections between modes.**
+
+---
+
+## PHASE 1: SCAN
+
+### 1.1 Load Configuration
+
+Read these files first:
+- `data/settings.local.yaml` if exists, else `data/settings.yaml` (provider config)
+- `data/newsletter-lists.local.yaml` if exists, else `data/newsletter-lists.yaml` (allowlist + previously unsubscribed)
+- `data/newsletter-patterns.json` (detection patterns)
+
+### 1.2 Get Mailbox IDs
+
+Use the list_mailboxes tool (based on provider) to get:
+- **Inbox ID** (role: "inbox") - REQUIRED for filtering
+- **Unsubscribed folder ID** (name contains "Unsubscribed") - for organizing
+
+### 1.3 Search Inbox for Newsletters
+
+**CRITICAL: Always filter to Inbox only!**
+
+Use advanced_search with:
+- mailboxId: [Inbox ID from step 1.2]
+- query: header:"List-Unsubscribe" OR header:"List-Id"
+- limit: 200
+
+### 1.4 Filter and Analyze
+
+For each email found:
+1. Check if sender domain is in allowlist -> **skip if yes**
+2. Check if sender is in unsubscribed list -> **flag as REPEAT OFFENDER**
+3. Get full email with get_email to extract unsubscribe link
+4. Group by sender domain, count frequency
+
+**Extract unsubscribe link from:**
+- `List-Unsubscribe` header (preferred) - format: `<mailto:...>, <https://...>`
+- HTML body - look for links with "unsubscribe", "opt out", "manage preferences"
+
+**Store for each newsletter:**
+```
+{
+  senderDomain: "example.com",
+  senderName: "Example Newsletter",
+  unsubscribeUrl: "https://...",
+  unsubscribeMailto: "mailto:...",
+  emailCount: 5,
+  emailIds: ["id1", "id2"],
+  isRepeatOffender: false,
+  previousUnsubDate: null
+}
+```
+
+### 1.5 Return Results
+
+In SCAN mode, return the structured list to the parent agent (see MODE 1 format above).
+
+If no newsletters found, report "No newsletters found, your inbox is clean!"
+
+In EXECUTE mode, proceed to PHASE 2 with the selections provided in the prompt.
+
+---
+
+## PHASE 2: EXECUTE
+
+### 2.1 Process Each Selected Newsletter
+
+For each newsletter specified in the EXECUTE prompt (with URLs and email IDs):
+
+**Option A: Web unsubscribe (preferred)**
+```
+1. mcp__plugin_playwright_playwright__browser_navigate -> unsubscribe URL
+2. mcp__plugin_playwright_playwright__browser_snapshot -> get page structure
+3. Find and click "Unsubscribe" / "Confirm" button using browser_click
+4. browser_snapshot again to verify success
+5. Record result (success/failure)
+```
+
+**Option B: Mailto unsubscribe (fallback)**
+Use the send_email tool with:
+- to: [extracted mailto address]
+- subject: "unsubscribe"
+- textBody: "Please unsubscribe me from this mailing list."
+
+**Handle failures gracefully:**
+- CAPTCHA detected -> Record failure, save URL for manual action
+- Login required -> Record failure, save URL for manual action
+- Timeout -> Retry once, then record failure
+
+### 2.2 Close Browser
+
+```
+Tool: mcp__plugin_playwright_playwright__browser_close
+```
+
+### 2.3 Process Allowlist Additions
+
+If the EXECUTE prompt includes domains to add to the allowlist (e.g., "ALLOWLIST: domain.com"), add them to the allowlist in newsletter-lists.local.yaml.
+
+---
+
+## PHASE 3: CLEANUP
+
+### 3.1 Update newsletter-lists.local.yaml
+
+Read current file (`newsletter-lists.local.yaml` if exists, else `newsletter-lists.yaml`), merge changes, write back to `newsletter-lists.local.yaml` (create if needed) to keep personal data gitignored:
+
+**Add to unsubscribed list:**
+```yaml
+unsubscribed:
+  - domain: example.com
+    email: newsletter@example.com
+    name: "Example Newsletter"
+    unsubscribed_date: "2026-01-21"
+    method: web  # or mailto
+```
+
+**Add to allowlist:**
+```yaml
+allowlist:
+  - stratechery.com  # User-selected to keep
+```
+
+### 3.2 Move Emails to Unsubscribed Folder
+
+Use bulk_move tool with:
+- emailIds: [list of email IDs from unsubscribed newsletters]
+- targetMailboxId: [Unsubscribed folder ID]
+
+### 3.3 Report Summary
+
+```
+Newsletter Unsubscribe Summary
+==============================
+
+REPEAT OFFENDERS (1):
+- spammy.com - Unsubscribed 2025-11-15, sent 3 more!
+  -> Unsubscribed again via web form
+
+Successfully unsubscribed (2):
+- example.com (15 emails) - via web form
+- news-site.com (8 emails) - via mailto
+
+Failed (1):
+- protected.com - CAPTCHA required
+  Manual URL: https://protected.com/unsubscribe?token=xxx
+
+Added to allowlist (1):
+- stratechery.com
+
+Lists updated: newsletter-lists.local.yaml
+Emails moved: 23 -> Unsubscribed folder
+```
+
+**NOW you may return to parent agent.**
+
+---
+
+## REFERENCE: Available Tools
+
+### Email Tools (Provider-Dependent)
+
+Read settings.yaml first to determine which tools to use:
+- **list_mailboxes** - Get all folders (Inbox ID, Unsubscribed folder ID)
+- **advanced_search** - Search with mailboxId filter and header queries
+- **search_emails** - Fallback search when header search returns empty
+- **get_email** - Get full email content with htmlBody and headers
+- **send_email** - Send unsubscribe emails (for mailto links)
+- **bulk_move** - Move multiple emails to Unsubscribed folder
+- **bulk_mark_read** - Mark processed emails as read
+
+### Playwright Tools
+Use `mcp__plugin_playwright_playwright__*` or `mcp__plugin_newsletter-unsubscriber_playwright__*`:
+- `browser_navigate` - Go to unsubscribe URL
+- `browser_snapshot` - Get page structure (preferred over screenshot)
+- `browser_click` - Click unsubscribe/confirm buttons
+- `browser_type` - Enter email address in forms
+- `browser_fill_form` - Fill multiple form fields at once
+- `browser_close` - Close browser when done (required!)
+
+### Other Tools
+- `AskUserQuestion` - Get user selections (max 4 options, present one batch at a time)
+- `Read` - Read patterns and lists configuration files
+- `Write` - Update newsletter-lists.local.yaml with allowlist and unsubscribed entries
+
+## Important Guidelines
+
+1. **INBOX ONLY** - Always filter to Inbox with mailboxId
+2. **Load lists first** - Always load newsletter-lists.local.yaml (or newsletter-lists.yaml) before scanning
+3. **Skip allowlisted** - Never show allowlisted senders to user
+4. **Flag repeat offenders** - Highlight senders who ignore unsubscribe requests
+5. **User consent** - Always get explicit user selection before unsubscribing
+6. **Double confirm** - Show confirmation before executing
+7. **Update lists** - Always update newsletter-lists.local.yaml after actions
+8. **Offer allowlist** - Ask user if they want to allowlist newsletters they're keeping
+9. **Prefer web links** - More reliable than mailto for verification
+10. **Extract recipient email** - Use the To: header from original email
+11. **Handle errors gracefully** - Report failures with manual URLs
+12. **Close browser** - Always close Playwright when done
+13. **Be conservative** - When in doubt, report as failed and provide URL
+14. **Batch efficiently** - Use bulk_move for email organization
+15. **Limit options** - Max 3 newsletters + "None of these" per AskUserQuestion
+16. **Always include "None"** - Every batch must have explicit skip option
+
+## Auto-Approval Configuration
+
+The plugin includes `.claude/settings.local.json` to auto-approve writes to the data directory:
+```json
+{
+  "permissions": {
+    "allow": [
+      "Write(data/**)",
+      "Edit(data/**)"
+    ]
+  }
+}
+```
+This prevents prompts when updating `newsletter-lists.local.yaml`.
+
+## Newsletter Detection via RFC Headers
+
+**Primary detection (most reliable):**
+The search query `header:"List-Unsubscribe" OR header:"List-Id"` catches newsletters because:
+- `List-Unsubscribe` (RFC 2369) - Required by Gmail/Yahoo for marketing emails since June 2024
+- `List-Id` (RFC 2919) - Standard identifier for mailing lists
+- `List-Unsubscribe-Post` (RFC 8058) - Enables one-click unsubscribe
+
+**These emails will NOT match the header search:**
+- Transactional emails (orders, receipts, shipping) - no List-Unsubscribe header
+- Account notifications (password reset, security) - no List-Unsubscribe header
+- Direct correspondence - no mailing list headers
+- Spam without proper headers
+
+**Extracting unsubscribe URL from List-Unsubscribe header:**
+The header format is: `List-Unsubscribe: <mailto:unsub@example.com>, <https://example.com/unsubscribe?id=123>`
+- May contain mailto: link, https: link, or both
+- Links are enclosed in angle brackets
+- Prefer https: over mailto: when both present

--- a/plugins/newsletter-unsubscriber/commands/setup.md
+++ b/plugins/newsletter-unsubscriber/commands/setup.md
@@ -1,0 +1,103 @@
+---
+description: Configure email provider for newsletter-unsubscriber
+---
+
+# /newsletter-unsubscriber:setup
+
+Configure your email provider for the newsletter-unsubscriber plugin.
+
+## What This Does
+
+1. Checks for required MCP servers (email provider, Playwright)
+2. Shows installation commands if any are missing
+3. Asks you to select your email provider
+4. Saves configuration to `data/settings.yaml`
+
+## Setup Process
+
+### Step 1: Check for Email Provider MCP
+
+Check if the user has an email MCP server configured. Use `claude mcp list` via Bash to check.
+
+**Supported Email Providers:**
+
+| Provider | How to Check | Installation |
+|----------|--------------|--------------|
+| Fastmail | Look for `fastmail` in mcp list | Custom MCP server |
+| Gmail | Look for `gmail` in mcp list | `npx -y @smithery/cli@latest install gmail --client claude` |
+| Outlook | Look for `outlook` in mcp list | `npx -y @smithery/cli@latest install outlook --client claude` |
+
+If no email provider is found, display:
+```
+No email MCP server found. Please install one:
+
+For Gmail:
+  npx -y @smithery/cli@latest install gmail --client claude
+
+For Outlook:
+  npx -y @smithery/cli@latest install outlook --client claude
+
+For Fastmail:
+  (Custom setup required - see documentation)
+```
+
+### Step 2: Check for Playwright
+
+Playwright is bundled with this plugin via `.mcp.json`. It should be available automatically.
+
+If not working, the user may need to install the Playwright MCP server:
+```
+npm install -g @playwright/mcp
+```
+
+### Step 3: Ask User for Email Provider Selection
+
+Use AskUserQuestion to ask which email provider to use:
+
+```
+Tool: AskUserQuestion
+Parameters:
+  questions: [{
+    question: "Which email provider would you like to use?",
+    header: "Email",
+    multiSelect: false,
+    options: [
+      { label: "Fastmail", description: "Use Fastmail MCP" },
+      { label: "Gmail", description: "Use Gmail MCP" },
+      { label: "Outlook", description: "Use Outlook/Microsoft 365 MCP" }
+    ]
+  }]
+```
+
+### Step 4: Save Configuration
+
+Update `data/settings.local.yaml` (create if it doesn't exist):
+
+```yaml
+providers:
+  email:
+    active: [selected provider]
+    # ... mappings stay the same
+
+setup_date: "YYYY-MM-DD"
+```
+
+### Step 5: Confirm Setup
+
+Display confirmation message:
+```
+newsletter-unsubscriber configured successfully!
+
+Email Provider: [provider]
+Browser Automation: Playwright (bundled)
+
+Run /newsletter-unsubscriber:unsubscribe to start cleaning up newsletters.
+```
+
+## Implementation
+
+Use these tools:
+- `Bash` with `claude mcp list` to check installed MCP servers
+- `AskUserQuestion` to prompt for provider selection
+- `Read` to load current settings.yaml
+- `Write` to save updated settings.yaml

--- a/plugins/newsletter-unsubscriber/commands/unsubscribe.md
+++ b/plugins/newsletter-unsubscriber/commands/unsubscribe.md
@@ -1,0 +1,115 @@
+---
+description: Scan inbox for newsletters and help unsubscribe from unwanted ones
+---
+
+# /newsletter-unsubscriber:unsubscribe
+
+Scan your inbox for newsletters and help you unsubscribe from the ones you no longer want.
+
+## Usage
+
+```
+/newsletter-unsubscriber:unsubscribe
+```
+
+## What It Does
+
+1. **Loads your lists** - Reads allowlist and previously unsubscribed senders
+2. **Scans inbox** for newsletters (skips allowlisted senders)
+3. **Flags repeat offenders** - Highlights senders who ignored previous unsubscribes
+4. **Groups newsletters** by sender domain with frequency counts
+5. **Asks which to unsubscribe** - You select which newsletters to remove
+6. **Confirms your selection** before taking action
+7. **Executes unsubscribes** via mailto or web forms
+8. **Asks about allowlist** - Offers to add skipped newsletters to allowlist
+9. **Updates your lists** - Tracks unsubscribed senders + allowlist additions
+10. **Organizes emails** by moving them to Newsletters/Unsubscribed folder
+
+## Newsletter Detection
+
+Uses RFC 2369 email headers to precisely identify newsletters:
+- **`List-Unsubscribe`** - The definitive newsletter/mailing list indicator
+- **`List-Id`** - Identifies mailing lists
+
+This is far more accurate than guessing from subject lines. Gmail and Yahoo require these headers for marketing emails since June 2024.
+
+## Allowlist & Repeat Offender Tracking
+
+The agent maintains two lists in `data/newsletter-lists.yaml`:
+
+| List | Purpose |
+|------|---------|
+| **Allowlist** | Newsletters you want to keep - skipped in future scans |
+| **Unsubscribed** | Senders you've unsubscribed from - used to detect repeat offenders |
+
+**Repeat offenders** are senders who continue emailing after you unsubscribed. These are flagged in the selection list so you can take action.
+
+## Unsubscribe Methods
+
+| Method | How It Works |
+|--------|--------------|
+| Mailto | Sends "unsubscribe" email to the list address |
+| Web Form (simple) | Clicks "Unsubscribe" button on page |
+| Web Form (email) | Enters your email and submits |
+| Web Form (multi-step) | Follows through confirmation pages |
+
+## Failure Scenarios
+
+Some unsubscribes may fail and require manual action:
+
+| Issue | What Happens |
+|-------|--------------|
+| CAPTCHA | Provides URL for manual unsubscribe |
+| Login required | Provides URL for manual unsubscribe |
+| Timeout | Retries once, then reports failure |
+| Complex flow | Reports failure with URL |
+
+## Example Output
+
+```
+Newsletter Unsubscribe Summary
+==============================
+
+REPEAT OFFENDERS (1):
+- spammy.com - Unsubscribed 2025-12-01, sent 3 more emails!
+  -> Unsubscribed again via web form
+
+Successfully unsubscribed (3):
+- marketing-company.com (12 emails) - via web form
+- news-digest.com (10 emails) - via mailto
+- tech-updates.io (8 emails) - via web form
+
+Failed to unsubscribe (1):
+- protected-site.com (3 emails) - CAPTCHA required
+  Manual URL: https://protected-site.com/unsubscribe?token=xxx
+
+Added to allowlist (2):
+- stratechery.com - Will skip in future scans
+- join1440.com - Will skip in future scans
+
+Lists updated: newsletter-lists.yaml
+Emails organized: 28 emails moved to Newsletters/Unsubscribed folder
+```
+
+## Implementation
+
+This command uses a two-phase workflow:
+
+### Phase 1: Scan (agent returns data)
+```
+subagent_type: "newsletter-unsubscriber:newsletter-unsubscriber"
+prompt: "Scan inbox for newsletters. Return the structured list - do not use AskUserQuestion."
+```
+
+### Phase 2: User Selection (parent handles)
+The parent agent uses AskUserQuestion to present newsletters and get user selections.
+
+### Phase 3: Execute (agent performs actions)
+```
+subagent_type: "newsletter-unsubscriber:newsletter-unsubscriber"
+prompt: "Execute these actions:
+- UNSUBSCRIBE: domain1.com (url: https://example.com/unsubscribe?id=123, emailIds: [msg1, msg2])
+- UNSUBSCRIBE: domain2.com (url: https://other.com/unsub, emailIds: [msg3])
+- ALLOWLIST: domain3.com, domain4.com
+Then update newsletter-lists.local.yaml and move emails to Unsubscribed folder."
+```

--- a/plugins/newsletter-unsubscriber/data/.gitignore
+++ b/plugins/newsletter-unsubscriber/data/.gitignore
@@ -1,0 +1,5 @@
+# Personal data - not tracked in public repo
+newsletter-lists.local.yaml
+settings.local.yaml
+
+# The template files (newsletter-lists.yaml, settings.yaml) ARE tracked

--- a/plugins/newsletter-unsubscriber/data/newsletter-lists.yaml
+++ b/plugins/newsletter-unsubscriber/data/newsletter-lists.yaml
@@ -1,0 +1,20 @@
+# Newsletter Management Lists
+# Managed by the newsletter-unsubscriber agent
+
+# Newsletters you want to keep receiving - these are skipped during scans
+# Format: sender domain or email pattern
+allowlist:
+  # Add domains here that you want to keep receiving
+  # Example:
+  # - stratechery.com        # Tech newsletter
+  # - github.com             # GitHub notifications
+
+# Newsletters you've unsubscribed from - used to detect repeat offenders
+# This is automatically populated by the agent when you unsubscribe
+# Format:
+#   - domain: example.com
+#     email: newsletter@example.com
+#     name: "Example Newsletter"
+#     unsubscribed_date: "2026-01-01"
+#     method: web  # or mailto
+unsubscribed: []

--- a/plugins/newsletter-unsubscriber/data/newsletter-patterns.json
+++ b/plugins/newsletter-unsubscriber/data/newsletter-patterns.json
@@ -1,0 +1,228 @@
+{
+  "headerSearchQueries": {
+    "primary": "header:\"List-Unsubscribe\" OR header:\"List-Id\"",
+    "newslettersOnly": "header:\"List-Unsubscribe\"",
+    "includeBulk": "header:\"List-Unsubscribe\" OR header:\"List-Id\" OR header:\"Precedence: bulk\"",
+    "oneClickCapable": "header:\"List-Unsubscribe-Post\""
+  },
+  "rfcHeaders": {
+    "List-Unsubscribe": "RFC 2369 - Contains mailto: and/or https: unsubscribe URLs",
+    "List-Unsubscribe-Post": "RFC 8058 - Enables one-click unsubscribe (List-Unsubscribe=One-Click)",
+    "List-Id": "RFC 2919 - Identifies the mailing list",
+    "Precedence": "Often 'bulk' or 'list' for mass mail",
+    "Feedback-ID": "ESP complaint tracking header"
+  },
+  "espCampaignHeaders": [
+    "X-Campaign",
+    "X-Mailgun-Campaign-Id",
+    "X-MC-Campaign",
+    "X-Sendgrid-Campaign-Id",
+    "X-Mailer",
+    "X-SES-Outgoing"
+  ],
+  "newsletterServiceDomains": [
+    "mailchimp.com",
+    "sendgrid.net",
+    "substack.com",
+    "constantcontact.com",
+    "mailgun.org",
+    "sparkpostmail.com",
+    "amazonses.com",
+    "hubspot.com",
+    "klaviyo.com",
+    "sailthru.com",
+    "braze.com",
+    "iterable.com",
+    "customer.io",
+    "intercom-mail.com",
+    "postmarkapp.com",
+    "sendinblue.com",
+    "mailjet.com",
+    "convertkit.com",
+    "drip.com",
+    "activecampaign.com",
+    "campaignmonitor.com",
+    "getresponse.com",
+    "aweber.com",
+    "beehiiv.com",
+    "ghost.io",
+    "buttondown.email",
+    "revue.co",
+    "tinyletter.com"
+  ],
+  "bulkSenderPatterns": [
+    "noreply@",
+    "no-reply@",
+    "newsletter@",
+    "news@",
+    "digest@",
+    "updates@",
+    "marketing@",
+    "promotions@",
+    "info@",
+    "hello@",
+    "team@",
+    "mail@",
+    "email@",
+    "subscribe@",
+    "notifications@",
+    "alerts@",
+    "weekly@",
+    "daily@",
+    "monthly@"
+  ],
+  "unsubscribeLinkTextPatterns": [
+    "unsubscribe",
+    "opt out",
+    "opt-out",
+    "optout",
+    "manage preferences",
+    "email preferences",
+    "update preferences",
+    "subscription preferences",
+    "manage subscription",
+    "update subscription",
+    "email settings",
+    "notification settings",
+    "stop receiving",
+    "remove me",
+    "click here to unsubscribe",
+    "if you no longer wish to receive",
+    "manage your email",
+    "change email preferences"
+  ],
+  "unsubscribeUrlPatterns": [
+    "unsubscribe",
+    "unsub",
+    "optout",
+    "opt-out",
+    "manage-preferences",
+    "email-preferences",
+    "subscription",
+    "preferences",
+    "list-manage",
+    "campaign-archive",
+    "email-settings",
+    "notification-settings",
+    "mailing-list",
+    "remove"
+  ],
+  "subjectIndicators": {
+    "newsletter": [
+      "newsletter",
+      "weekly",
+      "daily",
+      "monthly",
+      "digest",
+      "roundup",
+      "round-up",
+      "update",
+      "bulletin",
+      "briefing",
+      "recap",
+      "highlights",
+      "this week",
+      "this month",
+      "edition"
+    ],
+    "marketing": [
+      "% off",
+      "sale",
+      "deal",
+      "promo",
+      "discount",
+      "limited time",
+      "exclusive offer",
+      "special offer",
+      "flash sale",
+      "clearance",
+      "save now",
+      "shop now",
+      "buy now",
+      "free shipping",
+      "last chance"
+    ]
+  },
+  "excludePatterns": {
+    "transactional": [
+      "order confirmation",
+      "shipping confirmation",
+      "delivery notification",
+      "receipt",
+      "invoice",
+      "payment received",
+      "refund processed",
+      "your order",
+      "track your",
+      "shipped",
+      "delivered"
+    ],
+    "account": [
+      "password reset",
+      "verify your email",
+      "confirm your email",
+      "security alert",
+      "login notification",
+      "account update",
+      "two-factor",
+      "2fa",
+      "authentication"
+    ],
+    "direct": [
+      "re:",
+      "fwd:",
+      "replied to your"
+    ]
+  },
+  "searchQueries": {
+    "primary": "header:\"List-Unsubscribe\" OR header:\"List-Id\"",
+    "fallbackKeywords": "unsubscribe OR \"manage preferences\" OR \"email preferences\""
+  },
+  "webFormPatterns": {
+    "confirmButtons": [
+      "unsubscribe",
+      "confirm",
+      "yes",
+      "submit",
+      "opt out",
+      "remove",
+      "unsubscribe me",
+      "confirm unsubscribe"
+    ],
+    "emailFields": [
+      "email",
+      "e-mail",
+      "email address",
+      "your email"
+    ],
+    "captchaIndicators": [
+      "captcha",
+      "recaptcha",
+      "hcaptcha",
+      "i'm not a robot",
+      "verify you're human",
+      "security check",
+      "challenge"
+    ],
+    "loginIndicators": [
+      "log in",
+      "sign in",
+      "login",
+      "signin",
+      "enter password",
+      "password",
+      "session expired",
+      "please authenticate"
+    ],
+    "successIndicators": [
+      "successfully unsubscribed",
+      "you have been unsubscribed",
+      "unsubscribe successful",
+      "removed from",
+      "you will no longer receive",
+      "subscription canceled",
+      "preferences updated",
+      "thank you"
+    ]
+  }
+}

--- a/plugins/newsletter-unsubscriber/data/settings.yaml
+++ b/plugins/newsletter-unsubscriber/data/settings.yaml
@@ -1,0 +1,41 @@
+# newsletter-unsubscriber Provider Configuration
+# Configure which email provider to use
+
+providers:
+  email:
+    # Active email provider: fastmail, gmail, outlook, apple-mail
+    # Run /newsletter-unsubscriber:setup to configure
+    active: null
+
+    # Provider-specific tool mappings
+    mappings:
+      fastmail:
+        list_mailboxes: mcp__fastmail__list_mailboxes
+        get_recent_emails: mcp__fastmail__get_recent_emails
+        search_emails: mcp__fastmail__search_emails
+        advanced_search: mcp__fastmail__advanced_search
+        get_email: mcp__fastmail__get_email
+        send_email: mcp__fastmail__send_email
+        bulk_move: mcp__fastmail__bulk_move
+        bulk_mark_read: mcp__fastmail__bulk_mark_read
+      gmail:
+        list_mailboxes: mcp__gmail__list_labels
+        get_recent_emails: mcp__gmail__list_messages
+        search_emails: mcp__gmail__search_messages
+        advanced_search: mcp__gmail__search_messages
+        get_email: mcp__gmail__get_message
+        send_email: mcp__gmail__send_message
+        bulk_move: mcp__gmail__modify_messages
+        bulk_mark_read: mcp__gmail__modify_messages
+      outlook:
+        list_mailboxes: mcp__outlook__list_folders
+        get_recent_emails: mcp__outlook__list_messages
+        search_emails: mcp__outlook__search_messages
+        advanced_search: mcp__outlook__search_messages
+        get_email: mcp__outlook__get_message
+        send_email: mcp__outlook__send_message
+        bulk_move: mcp__outlook__move_messages
+        bulk_mark_read: mcp__outlook__mark_read
+
+# Last setup: (updated by /newsletter-unsubscriber:setup)
+setup_date: null


### PR DESCRIPTION
## Summary

Extracts three email-related agents from `chief-of-staff` into standalone, reusable plugins with a provider/adapter model:

- **inbox-to-reminder** - Scan inbox for action items → Apple Reminders
- **newsletter-unsubscriber** - Find and unsubscribe from newsletters  
- **inbox-to-parcel** - Process shipping emails → Parcel app

## Features

- **Provider abstraction**: Supports Fastmail, Gmail, and Outlook via `settings.yaml`
- **Interactive setup**: Each plugin has `/plugin:setup` command for configuration
- **Local data**: Personal settings stored in `.local.yaml` files (gitignored)
- **Clean templates**: No PII in tracked files

## Plugin Structure

Each plugin includes:
- `.claude-plugin/plugin.json` - Plugin metadata
- `agents/*.md` - Main agent with provider abstraction
- `commands/setup.md` - Interactive setup command
- `commands/*.md` - User-invocable commands
- `data/settings.yaml` - Provider configuration template
- `data/.gitignore` - Protects `.local.yaml` files

## Also Includes

- `apple-pim` symlink for simplified local development
- Updated marketplace.json with new plugin entries

## Test plan

- [ ] Install each plugin: `/plugin install inbox-to-reminder@omar-agent-plugins`
- [ ] Run setup for each: `/inbox-to-reminder:setup`
- [ ] Verify commands work: `/inbox-to-reminder:scan`
- [ ] Confirm `.local.yaml` files are created and gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds three reusable, provider-abstracted email plugins and wires them into the marketplace.
> 
> - **New plugins**: `inbox-to-reminder`, `newsletter-unsubscriber`, `inbox-to-parcel` with `plugin.json`, agent specs, commands (`setup`, `scan`/`unsubscribe`/`track`), and READMEs
> - **Provider model**: Config via `data/settings.yaml` (+ `.local.yaml` gitignored) supporting Fastmail/Gmail/Outlook; Reminders via `apple-pim`; Parcel via `parcel-api-mcp`; Playwright MCP for web flows
> - **Data/templates**: Patterns and lists (`shipping-patterns.json`, `newsletter-patterns.json`, `newsletter-lists.yaml`) and data `.gitignore`
> - **Marketplace**: Bumps version to `1.1.0` and registers all three plugins
> 
> Emphasis on INBOX-only searches, safe setup flows, and duplicate/rate-limit handling for Parcel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9684f5ba16dd8300767041d5ded54d46613a72f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->