### PR TITLE
feat(inbox-triage): Add unified triage orchestrator with batch collection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Personal plugin marketplace for Claude Code",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [
@@ -47,33 +47,33 @@
     {
       "name": "inbox-to-reminder",
       "source": "./plugins/inbox-to-reminder",
-      "description": "Scan email inbox for action items and create reminders in Apple Reminders",
-      "version": "1.0.0",
-      "keywords": ["email", "reminders", "tasks", "bills", "deadlines"],
+      "description": "Scan email inbox for action items and create reminders in Apple Reminders (supports batch mode)",
+      "version": "1.1.0",
+      "keywords": ["email", "reminders", "tasks", "bills", "deadlines", "batch"],
       "category": "productivity"
     },
     {
       "name": "newsletter-unsubscriber",
       "source": "./plugins/newsletter-unsubscriber",
-      "description": "Scan inbox for newsletters and help unsubscribe from unwanted ones",
-      "version": "1.0.3",
-      "keywords": ["email", "newsletters", "unsubscribe", "cleanup"],
+      "description": "Scan inbox for newsletters and help unsubscribe from unwanted ones (supports batch mode)",
+      "version": "1.1.0",
+      "keywords": ["email", "newsletters", "unsubscribe", "cleanup", "batch"],
       "category": "productivity"
     },
     {
       "name": "inbox-to-parcel",
       "source": "./plugins/inbox-to-parcel",
-      "description": "Process shipping emails and add tracking to Parcel app",
-      "version": "1.0.0",
-      "keywords": ["email", "packages", "tracking", "parcel", "shipping"],
+      "description": "Process shipping emails and add tracking to Parcel app (supports batch mode)",
+      "version": "1.1.0",
+      "keywords": ["email", "packages", "tracking", "parcel", "shipping", "batch"],
       "category": "productivity"
     },
     {
       "name": "inbox-triage",
       "source": "./plugins/inbox-triage",
-      "description": "Self-learning email triage with pattern recognition, automated digests, and voice-friendly interview mode",
-      "version": "1.4.1",
-      "keywords": ["email", "triage", "inbox", "filing", "patterns", "learning", "interview", "voice"],
+      "description": "Self-learning email triage with pattern recognition, automated digests, and voice-friendly interview mode with batch orchestration",
+      "version": "1.5.0",
+      "keywords": ["email", "triage", "inbox", "filing", "patterns", "learning", "interview", "voice", "orchestrator"],
       "category": "productivity"
     }
   ]

--- a/plugins/inbox-to-parcel/.claude-plugin/plugin.json
+++ b/plugins/inbox-to-parcel/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inbox-to-parcel",
-  "version": "1.0.0",
-  "description": "Process shipping emails and add tracking to Parcel app",
+  "version": "1.1.0",
+  "description": "Process shipping emails and add tracking to Parcel app (supports batch mode)",
   "author": {
     "name": "Omar Shahine"
   },

--- a/plugins/inbox-to-reminder/.claude-plugin/plugin.json
+++ b/plugins/inbox-to-reminder/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "inbox-to-reminder",
-  "version": "1.0.0",
-  "description": "Scan email inbox for action items and create reminders in Apple Reminders",
+  "version": "1.1.0",
+  "description": "Scan email inbox for action items and create reminders in Apple Reminders (supports batch mode)",
   "author": {
     "name": "Omar Shahine"
   },

--- a/plugins/inbox-triage/.claude-plugin/plugin.json
+++ b/plugins/inbox-triage/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "inbox-triage",
-  "version": "1.4.1",
-  "description": "Self-learning email triage with pattern recognition, automated digests, and voice-friendly interview mode",
+  "version": "1.5.0",
+  "description": "Self-learning email triage with pattern recognition, automated digests, and voice-friendly interview mode with batch orchestration",
   "license": "MIT"
 }

--- a/plugins/inbox-triage/commands/configure.md
+++ b/plugins/inbox-triage/commands/configure.md
@@ -1,0 +1,95 @@
+---
+description: Configure inbox-triage integration settings
+argument-hint: "[--parcel on|off] [--reminders on|off] [--newsletter on|off] [--show]"
+---
+
+# /inbox-triage:configure
+
+View and modify integration settings for inbox-interviewer. These settings control which specialized features are available during interview mode.
+
+## Usage
+
+```
+/inbox-triage:configure              # Show current settings
+/inbox-triage:configure --show       # Show current settings (explicit)
+/inbox-triage:configure --parcel on  # Enable Parcel integration
+/inbox-triage:configure --parcel off # Disable Parcel integration
+/inbox-triage:configure --reminders on|off
+/inbox-triage:configure --newsletter on|off
+```
+
+## Available Integrations
+
+| Integration | Description | When Enabled |
+|-------------|-------------|--------------|
+| **Parcel** | Package tracking via inbox-to-parcel | "Add to Parcel" option for shipping emails |
+| **Reminders** | Reminder creation via Apple PIM | Auto-suggest reminder for action items |
+| **Newsletter** | Newsletter management via newsletter-unsubscriber | "Delete + Unsubscribe" option |
+| **Filing** | Core filing feature (always enabled) | Folder suggestions based on rules |
+
+## Implementation
+
+1. **Find data directory**: Use Glob to find `~/.claude/plugins/cache/*/inbox-triage/*/data/settings.yaml`
+
+2. **Read current settings**: Load the `integrations` section from settings.yaml
+
+3. **If no arguments or --show**: Display current settings:
+```
+Inbox Triage Integration Settings
+================================
+
+Parcel (inbox-to-parcel):     ENABLED
+  - Auto-archive to: Orders
+
+Reminders (Apple PIM):        ENABLED
+  - Default list: Reminders
+  - Auto-detect action items: Yes
+
+Newsletter (newsletter-unsubscriber): ENABLED
+  - Offer unsubscribe: Yes
+
+Filing (core):                ENABLED (always on)
+  - Min confidence: 70%
+```
+
+4. **If arguments provided**: Update the settings.yaml file:
+   - Parse arguments: `--parcel`, `--reminders`, `--newsletter` with `on` or `off`
+   - Update the corresponding `integrations.[name].enabled` value
+   - Write back to settings.yaml
+   - Confirm the change
+
+## Examples
+
+**Show settings:**
+```
+> /inbox-triage:configure
+
+Inbox Triage Integration Settings
+================================
+Parcel:      ENABLED
+Reminders:   ENABLED
+Newsletter:  ENABLED
+Filing:      ENABLED (always on)
+```
+
+**Disable Parcel:**
+```
+> /inbox-triage:configure --parcel off
+
+Updated: Parcel integration DISABLED
+Interview mode will no longer offer "Add to Parcel" for shipping emails.
+```
+
+**Enable Newsletter:**
+```
+> /inbox-triage:configure --newsletter on
+
+Updated: Newsletter integration ENABLED
+Interview mode will offer "Delete + Unsubscribe" for detected newsletters.
+```
+
+## Notes
+
+- Changes take effect immediately for new interview sessions
+- Filing cannot be disabled (it's the core feature)
+- Settings are stored in the plugin's data directory

--- a/plugins/newsletter-unsubscriber/.claude-plugin/plugin.json
+++ b/plugins/newsletter-unsubscriber/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "newsletter-unsubscriber",
-  "version": "1.0.3",
-  "description": "Scan inbox for newsletters and help unsubscribe from unwanted ones",
+  "version": "1.1.0",
+  "description": "Scan inbox for newsletters and help unsubscribe from unwanted ones (supports batch mode)",
   "author": {
     "name": "Omar Shahine"
   },

--- a/plugins/newsletter-unsubscriber/agents/newsletter-unsubscriber.md
+++ b/plugins/newsletter-unsubscriber/agents/newsletter-unsubscriber.md
@@ -75,22 +75,34 @@ When prompt says "scan" without specific selections:
 - domain.com - order confirmation (no List-Unsubscribe header)
 ```
 
-### MODE 2: EXECUTE
-When prompt includes specific selections like "unsubscribe from X, Y" or "add Z to allowlist":
-1. Execute the requested unsubscribes via web form or mailto (using provided URLs)
-2. Add specified domains to allowlist
-3. Update newsletter-lists.local.yaml
-4. Move processed emails to Unsubscribed folder (using provided email IDs)
-5. Return summary of actions taken
+### MODE 2: EXECUTE (Batch Mode)
+When prompt includes `UNSUBSCRIBE:` followed by specific selections, operate in batch unsubscribe mode.
 
-**Expected input format for EXECUTE mode:**
-The prompt should include unsubscribe URLs and email IDs for each selected newsletter:
+**Batch Input Format (from inbox-interviewer):**
+```json
+[
+  {"domain": "example.com", "unsubscribeUrl": "https://...", "emailIds": ["id1", "id2"]},
+  {"domain": "news-site.com", "unsubscribeUrl": "https://...", "emailIds": ["id3"]}
+]
+```
+
+Or in text format:
 ```
 UNSUBSCRIBE: domain.com (url: https://..., emailIds: [id1, id2])
 ALLOWLIST: domain2.com
 ```
 
-**The parent agent handles AskUserQuestion for user selections between modes.**
+**Batch Mode Workflow:**
+1. Parse the batch data (JSON array or text format)
+2. Execute unsubscribes via web form or mailto (using provided URLs)
+3. Add any specified domains to allowlist
+4. Update newsletter-lists.local.yaml
+5. Move processed emails to Unsubscribed folder (using provided email IDs)
+6. Return summary of actions taken
+
+**Do NOT ask the user any questions in batch mode - just process and report.**
+
+**The parent agent (inbox-interviewer) handles user selections and batches them here.**
 
 ---
 


### PR DESCRIPTION
## Summary

Enhance inbox-interviewer to be a **unified triage orchestrator** with a two-phase architecture:

1. **Interview Phase**: Process emails one-by-one, classify and collect user decisions into batches
2. **Execution Phase**: Delegate batches to specialized sub-agents for efficient execution

### Problem Solved

Previously, each plugin fetched emails independently:
- `/inbox-triage:interview` → fetches inbox, suggests actions (inline execution)
- `/inbox-to-parcel:track` → fetches inbox again, adds to Parcel
- `/inbox-to-reminder:scan` → fetches inbox again, creates reminders
- `/newsletter-unsubscriber:unsubscribe` → fetches inbox again

**Issues addressed:**
- Redundant fetches (multiple inbox scans)
- Inline execution (no batching)
- No sub-agent delegation

### Changes

| Plugin | Version | Changes |
|--------|---------|---------|
| inbox-triage | 1.5.0 | Batch storage, integration settings, sub-agent delegation |
| inbox-to-parcel | 1.1.0 | Batch input mode for package processing |
| inbox-to-reminder | 1.1.0 | Batch input mode for reminder creation |
| newsletter-unsubscriber | 1.1.0 | Clarified batch mode documentation |

### New Features

- **Batch collection**: Package, newsletter, and reminder actions collected during interview
- **Sub-agent delegation**: Task tool launches specialized agents at session end
- **Configurable integrations**: New `integrations` section in settings.yaml
- **Configure command**: `/inbox-triage:configure` to toggle integrations

### Architecture

```
Interview Phase (inbox-interviewer)
    │
    ├── Fetch inbox emails (single fetch)
    ├── For each email:
    │   ├── Classify (package? newsletter? action item?)
    │   ├── Present options to user
    │   └── Collect decision into appropriate batch
    │
    └── Batches collected:
        ├── parcel_batch: [{emailId, trackingNumber, carrier}, ...]
        ├── unsubscribe_batch: [{emailId, unsubscribeUrl, domain}, ...]
        ├── reminder_batch: [{emailId, title, dueDate, list}, ...]
        └── archive/delete batches

Execution Phase (end of session)
    │
    ├── Task: inbox-to-parcel sub-agent → Receives parcel_batch
    ├── Task: newsletter-unsubscriber sub-agent → Receives unsubscribe_batch
    └── Task: inbox-to-reminder sub-agent → Receives reminder_batch
```

## Test plan

- [ ] Test interview mode with package email - verify "Add to Parcel" option appears
- [ ] Test interview mode with newsletter - verify "Delete + Unsubscribe" option appears
- [ ] Test batch collection by selecting multiple specialized options
- [ ] Test end-of-session delegation to sub-agents
- [ ] Test `/inbox-triage:configure --parcel off` disables Parcel option
- [ ] Test resume with pending batches

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how triage actions are executed (deferring package/newsletter/reminder work to end-of-session sub-agent runs) and introduces new integration gating/resume semantics that could alter user-visible behavior if misconfigured.
> 
> **Overview**
> **`inbox-triage` is updated to batch-orchestrate triage actions**: during the interview it now *collects* package tracking, newsletter unsubscribes, and reminder creation into persisted `batches` (tracked in `interview-state.yaml`), while archive/delete/keep/reply remain inline.
> 
> At session end, `inbox-interviewer` now **delegates queued batches via the Task tool** to `inbox-to-parcel`, `newsletter-unsubscriber`, and `inbox-to-reminder`, preserving session state for `--resume` retries if delegation fails.
> 
> Adds **integration-gated behavior** driven by a new `integrations.*.enabled` section in settings (and a new `/inbox-triage:configure` command doc to toggle/show these flags), plus plugin marketplace/version metadata updates and batch-mode docs/version bumps for the affected sub-agents.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9818c67cf271c068c7ccbc9a8e1a83136b892947. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->