### PR TITLE
feat(chief-of-staff): Add mcp frontmatter to agents for scoped MCP loading

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "chief-of-staff",
       "source": "./plugins/chief-of-staff",
       "description": "The orchestrator plugin for personal productivity - inbox triage, package tracking, reminder creation, newsletter management, and more",
-      "version": "1.2.2",
+      "version": "1.4.0",
       "keywords": ["email", "inbox", "triage", "packages", "parcel", "reminders", "newsletters", "unsubscribe", "productivity", "orchestrator", "filing", "patterns", "learning"],
       "category": "productivity"
     },

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Install the main orchestrator plugin:
 
 | Command | Description |
 |---------|-------------|
-| `/chief-of-staff:setup` | Configure email provider (Fastmail active) |
+| `/chief-of-staff:setup` | Configure email provider (Fastmail, Gmail, Outlook) |
 | `/chief-of-staff:daily` | Full daily orchestration routine |
 | `/chief-of-staff:status` | Quick dashboard of inbox status |
 | `/chief-of-staff:triage` | Interactive questions-first triage |
@@ -132,7 +132,7 @@ PHASE 3: LEARN (improve suggestions)
 
 | You Say | What Happens |
 |---------|--------------|
-| "Need to create a rule" | Archives + creates reminder to make Fastmail rule |
+| "Need to create a rule" | Archives + creates reminder to make a server-side rule |
 | "Flag for later" | Keeps in inbox + flags for follow-up |
 | "Read and summarize" | Summarizes content, shows at end, then archives/deletes |
 
@@ -147,7 +147,7 @@ Extracts tracking numbers from shipping emails and adds to Parcel app.
 - Supports: UPS, FedEx, USPS, DHL, OnTrac, Amazon
 - Moves processed emails to Orders folder
 - **Direct command**: `/chief-of-staff:parcel`
-- **Requires**: Email MCP + Parcel API MCP server
+- **Requires**: Parcel, Playwright MCPs (email loads via ToolSearch)
 
 #### newsletter-unsubscriber
 
@@ -157,7 +157,7 @@ Handles unwanted newsletter unsubscription.
 - Executes via mailto or web forms (uses Playwright)
 - Maintains allowlist of wanted newsletters
 - **Direct command**: `/chief-of-staff:unsubscribe`
-- **Requires**: Email MCP + Playwright plugin
+- **Requires**: Playwright MCP (email loads via ToolSearch)
 
 #### inbox-to-reminder
 
@@ -167,7 +167,7 @@ Creates Apple Reminders from emails requiring action.
 - Creates reminders with appropriate due dates
 - Routes to correct reminder list
 - **Direct command**: `/chief-of-staff:reminders`
-- **Requires**: Email MCP + `apple-pim` plugin
+- **Requires**: `apple-pim` plugin (loads via ToolSearch)
 
 #### Other Sub-Agents
 
@@ -184,8 +184,16 @@ Creates Apple Reminders from emails requiring action.
 
 ### Requirements
 
-- Email MCP server (Fastmail active; Gmail/Outlook planned)
+- Email MCP server (Fastmail, Gmail, or Outlook)
 - Existing folder structure to learn from
+
+### Provider-Agnostic Architecture
+
+Chief-of-Staff agents are **email provider-agnostic**. The active email provider is configured in `settings.yaml`, and agents dynamically load the appropriate email tools via ToolSearch at runtime.
+
+Only **fixed** integrations (Parcel, Playwright, Apple PIM) are declared in agent frontmatter. This means:
+- Switch email providers by updating `settings.yaml` - no agent changes needed
+- Gmail and Outlook support ready when MCP servers are available
 
 ### Private Extensions
 

--- a/plugins/chief-of-staff/.claude-plugin/plugin.json
+++ b/plugins/chief-of-staff/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "chief-of-staff",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "The orchestrator plugin for personal productivity - inbox triage, package tracking, reminder creation, newsletter management, and more",
   "author": {
     "name": "Omar Shahine"

--- a/plugins/chief-of-staff/agents/batch-processor.md
+++ b/plugins/chief-of-staff/agents/batch-processor.md
@@ -14,8 +14,6 @@ description: |
   user: "/chief-of-staff:batch --process"
   assistant: "Let me use the batch-processor agent to process the decisions file."
   </example>
-mcp:
-  - apple-pim
 model: sonnet
 color: green
 tools:

--- a/plugins/chief-of-staff/agents/inbox-to-reminder.md
+++ b/plugins/chief-of-staff/agents/inbox-to-reminder.md
@@ -1,7 +1,5 @@
 ---
 description: "Use this agent to scan email inbox for action items and create reminders. This includes:\n\n- Checking inbox for emails with tasks, deadlines, or follow-ups\n- Identifying action items from specific senders (like family members)\n- Creating reminders with appropriate due dates and details\n- Organizing reminders into the correct lists (Budget & Finances, Travel, Family, etc.)\n- Scanning recent emails (last 7-30 days) for outstanding tasks\n\nExamples:\n\n<example>\nuser: \"Check my inbox for action items from my partner and create reminders\"\nassistant: \"I'll use the inbox-to-reminder agent to scan your inbox for emails from your partner and create reminders for any tasks.\"\n</example>\n\n<example>\nuser: \"Are there any bills I need to pay based on my recent emails?\"\nassistant: \"Let me use the inbox-to-reminder agent to check your inbox for any bill-related emails and set up payment reminders.\"\n</example>\n\n<example>\nuser: \"Scan my inbox for anything I need to follow up on this week\"\nassistant: \"I'll launch the inbox-to-reminder agent to review your recent emails and create reminders for any pending action items.\"\n</example>\n\n<example>\nuser: \"Check if there are any deadlines I'm missing from my emails\"\nassistant: \"I'll use the inbox-to-reminder agent to scan your inbox for emails with deadlines and create appropriate reminders.\"\n</example>"
-mcp:
-  - apple-pim
 model: sonnet
 color: green
 tools: "*"


### PR DESCRIPTION
## Summary

- Update plugin.json to v1.3.0 with inline MCP servers using env vars
- Add `mcp:` frontmatter to agents declaring their specific MCP dependencies
- Remove `.mcp.json` from git and add to `.gitignore` to prevent secret leakage
- **Remove `fastmail` from agent frontmatter** - email provider now loads dynamically via ToolSearch

## Changes

### Plugin Configuration
- Changed from `.mcp.json` reference to inline MCP servers in `plugin.json`
- Uses `${FASTMAIL_MCP_URL}` env var (users provide in `~/.claude/settings.local.json`)

### Agent MCP Declarations (Provider-Agnostic)

Only **fixed** MCPs are declared in frontmatter. Email provider tools load dynamically:

| Agent | MCPs in Frontmatter |
|-------|---------------------|
| inbox-to-parcel | parcel, playwright |
| inbox-to-reminder | apple-pim |
| newsletter-unsubscriber | playwright |
| batch-processor | apple-pim |
| All others (7 agents) | *(none - email loads via ToolSearch)* |

### Why This Works

- Agents already use ToolSearch with `+[provider]` (e.g., `+fastmail`) based on `settings.yaml`
- The `mcp:` frontmatter only pre-loads tools - email doesn't need to be there
- Makes agents ready for future Gmail/Outlook support without code changes

### Security
- Removed `.mcp.json` from git tracking
- Added `.mcp.json` patterns to `.gitignore`

## Benefits

- MCPs only load when their specific subagent is invoked
- Agents are email-provider agnostic (ready for Gmail/Outlook)
- Reduces context usage and improves performance
- Prevents secrets from leaking to git

## Test plan

- [ ] Verify plugin installs correctly with `/plugin install chief-of-staff@omarshahine-agent-plugins`
- [ ] Test `/chief-of-staff:triage` - email tools should load via ToolSearch
- [ ] Test `/chief-of-staff:parcel` - parcel + playwright from frontmatter, email via ToolSearch
- [ ] Confirm `.mcp.json` is not tracked after PR merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes plugin/agent MCP configuration and declared dependencies, which can break tool availability at runtime if misconfigured. No core business logic changes, but installation/setup and agent execution paths are affected.
> 
> **Overview**
> **Chief-of-Staff MCP/tooling configuration is updated to support scoped MCP loading.** Agents now declare fixed MCP dependencies via `mcp:` frontmatter (e.g., `parcel`/`playwright` for `inbox-to-parcel`, `playwright` for `newsletter-unsubscriber`) while email provider tools are intended to load dynamically via ToolSearch.
> 
> Documentation and marketplace metadata are refreshed to match this provider-agnostic model (Fastmail/Gmail/Outlook setup wording, requirements, and a new architecture note), and `chief-of-staff` is version-bumped to `1.4.0` in both the marketplace and plugin manifest.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceba5df7e03cec636300db00c604e9aef8cc31ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->