### PR TITLE
Add Playwright extension token env var for browser reuse

### DIFF
--- a/plugins/chief-of-staff/.mcp.json
+++ b/plugins/chief-of-staff/.mcp.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest", "--extension"]
+      "args": ["-y", "@playwright/mcp@latest", "--extension"],
+      "env": {
+        "PLAYWRIGHT_MCP_EXTENSION_TOKEN": "${PLAYWRIGHT_MCP_EXTENSION_TOKEN}"
+      }
     },
     "parcel": {
       "command": "${CLAUDE_PLUGIN_ROOT}/scripts/parcel-server.sh"


### PR DESCRIPTION
## Summary
- Adds `PLAYWRIGHT_MCP_EXTENSION_TOKEN` env var to chief-of-staff Playwright config
- Uses `${PLAYWRIGHT_MCP_EXTENSION_TOKEN}` reference (not hardcoded) since this repo is public
- Actual token lives in `.claude/settings.local.json` (gitignored)

This enables the `--extension` mode to connect to the user's real browser without the manual Allow/Reject prompt each time.

## Test plan
- [ ] Restart Claude Code after merging
- [ ] Verify Playwright connects to real browser with 1Password
- [ ] Confirm no Allow/Reject dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, configuration-only change that adds an environment variable to a local MCP server definition; no application logic or data handling is modified.
> 
> **Overview**
> Updates `plugins/chief-of-staff/.mcp.json` to pass `PLAYWRIGHT_MCP_EXTENSION_TOKEN` into the Playwright MCP server configuration via an `env` block, referencing `${PLAYWRIGHT_MCP_EXTENSION_TOKEN}`.
> 
> This keeps the token out of the repo while enabling Playwright `--extension` runs to reuse a trusted browser session without repeated authorization prompts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc3be212b9bf0c760dff73b0df6bd552f773bbf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->