### PR TITLE
feat: convert from marketplace to GitHub template repository

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,11 +1,11 @@
 {
-  "name": "omarshahine-agent-plugins",
+  "name": "my-plugins",
   "owner": {
-    "name": "Omar Shahine"
+    "name": "Your Name"
   },
   "metadata": {
-    "description": "Public plugin marketplace for Claude Code - email management, travel, file organization, and personal productivity",
-    "version": "2.0.2",
+    "description": "Template for building Claude Code personal assistant plugins - email management, travel, file organization, and productivity",
+    "version": "3.0.0",
     "pluginRoot": "./plugins"
   },
   "plugins": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,7 +433,7 @@ These must never be committed to tracked files:
 - **Physical addresses**: Real street addresses - use `123 Main St` placeholders
 - **Phone numbers**: US phone patterns (XXX-XXX-XXXX) - use `555-123-4567`
 - **API keys/secrets**: Hardcoded `api_key=`, `token=`, `secret=`, `Bearer [value]` - use `${VAR}` env vars
-- **Service-specific forwarding addresses**: `username@library.readwise.io` style personal identifiers
+- **Service-specific forwarding addresses**: `user@service.example.com` style personal identifiers
 - **User data files**: YAML/JSON in `plugins/*/data/` must be gitignored (only `*.example.*` and `.gitignore` tracked)
 
 ### Marketplace & Path Patterns (Non-blocking)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
-# Agent-Plugins Development Guide
+# Chief-of-Staff Template Development Guide
 
-This repository is a Claude Code plugin marketplace (`omarshahine-agent-plugins`) containing reusable plugins for email management, travel, file organization, and personal information management.
+This repository is a Claude Code plugin template containing reusable plugins for email management, travel, file organization, and personal information management.
 
 ## Quick Commands
 
 ```bash
 # Install a plugin from this marketplace
-/plugin install chief-of-staff@omarshahine-agent-plugins
+/plugin install chief-of-staff@my-plugins
 
 # Check MCP server status
 /mcp
@@ -15,13 +15,13 @@ This repository is a Claude Code plugin marketplace (`omarshahine-agent-plugins`
 # Task(subagent_type="chief-of-staff:inbox-interviewer", prompt="Triage my inbox")
 
 # Clear plugin cache (after changes)
-rm -rf ~/.claude/plugins/cache/omarshahine-agent-plugins/<plugin>
+rm -rf ~/.claude/plugins/cache/my-plugins/<plugin>
 ```
 
 ## Repository Structure
 
 ```
-Agent-Plugins/
+chief-of-staff-template/
 ├── .claude-plugin/
 │   └── marketplace.json       # Marketplace definition (plugins registry)
 ├── plugins/
@@ -230,10 +230,10 @@ Plugins in this repo are automatically available when the marketplace is added:
 
 ```bash
 # Add marketplace (one time)
-/plugin marketplace add omarshahine/Agent-Plugins
+/plugin marketplace add omarshahine/chief-of-staff-template
 
 # Install plugin (first time only - plugins auto-update when configured)
-/plugin install chief-of-staff@omarshahine-agent-plugins
+/plugin install chief-of-staff@my-plugins
 ```
 
 **Note:** Plugins auto-update when `autoUpdates: true` is set in plugin settings. Manual reinstall is only needed if auto-updates are disabled or to force an immediate update.
@@ -405,7 +405,7 @@ This plugin is sourced from an external GitHub repository rather than being bund
 
 **Usage:** Install via this marketplace - the plugin is listed here but code lives in the external repo:
 ```bash
-/plugin install apple-pim@omarshahine-agent-plugins
+/plugin install apple-pim@my-plugins
 ```
 
 See the [Apple-PIM-Agent-Plugin repo](https://github.com/omarshahine/Apple-PIM-Agent-Plugin) for full documentation.
@@ -456,8 +456,8 @@ These files/patterns are excluded from all checks:
 ### Plugin not loading
 1. Check `plugin.json` syntax
 2. Verify plugin is in `marketplace.json`
-3. Clear cache: `rm -rf ~/.claude/plugins/cache/omarshahine-agent-plugins/<plugin>`
-4. Reinstall: `/plugin install <plugin>@omarshahine-agent-plugins`
+3. Clear cache: `rm -rf ~/.claude/plugins/cache/my-plugins/<plugin>`
+4. Reinstall: `/plugin install <plugin>@my-plugins`
 
 ### Commands not showing in autocomplete
 - Remove any `name:` field from command frontmatter

--- a/README.md
+++ b/README.md
@@ -1,77 +1,55 @@
-# Agent-Plugins
+# Chief-of-Staff Plugin Template
 
-A personal plugin marketplace for Claude Code containing reusable plugins for email management, travel, personal information management, and productivity.
+A template for building your own Claude Code personal assistant plugin. Includes a full-featured email orchestrator, travel agent, credit card tracker, and file renamer as working examples.
 
-## Installation
+## Getting Started
 
-Add this marketplace to Claude Code:
+1. Click **Use this template** on GitHub to create your own repo
+2. Clone your new repo locally
+3. Register it as a local marketplace in Claude Code:
 
 ```bash
-/plugin marketplace add omarshahine/agent-plugins
+/plugin marketplace add ~/GitHub/your-repo-name
 ```
 
-Install the main orchestrator plugin:
+4. Install the plugins you want:
 
 ```bash
-# Chief-of-Staff - the uber orchestrator for personal productivity
-/plugin install chief-of-staff@omarshahine-agent-plugins
+/plugin install chief-of-staff@my-plugins
+/plugin install travel-agent@my-plugins
+/plugin install credit-card-benefits@my-plugins
+/plugin install rename-agent@my-plugins
+```
 
-# Related plugins (optional, enhance COS capabilities)
-/plugin install apple-pim@omarshahine-agent-plugins         # Calendar, Reminders, Contacts, Mail
-/plugin install travel-agent@omarshahine-agent-plugins      # Flight research & tracking
-/plugin install credit-card-benefits@omarshahine-agent-plugins  # Credit card benefit tracking
-/plugin install rename-agent@omarshahine-agent-plugins      # AI-powered file renaming
+5. Customize the plugins, add your own agents, and make it yours.
+
+> **Note**: The marketplace name (`my-plugins`) comes from the `name` field in `.claude-plugin/marketplace.json`. Change it to whatever you like.
+
+### Building MCP Servers
+
+If plugins include bundled MCP servers, run the setup script:
+
+```bash
+./setup.sh
 ```
 
 ---
 
-## How It Works: The Plugin Ecosystem
+## Included Plugins
 
-**Chief-of-Staff** is the central orchestrator - "one plugin to rule them all" for personal productivity. It consolidates email triage, package tracking, reminder creation, and newsletter management into a single unified system.
-
-```
-+-----------------------------------------------------------------------+
-|                        CHIEF-OF-STAFF                                 |
-|                  "One Plugin to Rule Them All"                        |
-|                                                                       |
-|   Built-in Sub-Agents:              Related Plugins:                  |
-|   - inbox-interviewer               - apple-pim (Calendar/Reminders/  |
-|   - inbox-to-parcel                       Contacts/Mail)              |
-|   - inbox-to-reminder               - travel-agent (Flights/Trips)    |
-|   - newsletter-unsubscriber         - credit-card-benefits            |
-|   - digest-generator                - rename-agent                    |
-|   - organization-analyzer                                             |
-|   - pattern-learner                                                   |
-|   - folder-optimizer                                                  |
-+-----------------------------------------------------------------------+
-```
-
-**When you run `/chief-of-staff:triage`, the orchestrator:**
-1. Fetches emails from your inbox
-2. Classifies each one (package, newsletter, financial, action item, etc.)
-3. Suggests actions based on learned patterns
-4. Routes to specialized sub-agents when you choose:
-   - "Add to Parcel" -> `inbox-to-parcel` extracts tracking, adds to Parcel app
-   - "Unsubscribe" -> `newsletter-unsubscriber` handles the unsubscribe flow
-   - "Create reminder" -> `inbox-to-reminder` creates Apple Reminder via `apple-pim`
-
-**Standalone plugins** (travel-agent, credit-card-benefits, rename-agent, apple-pim) work independently for their specific domains but integrate seamlessly with Chief-of-Staff.
-
----
-
-## chief-of-staff
+### chief-of-staff
 
 **The email orchestrator.** Self-learning email triage that classifies your inbox, suggests actions based on your patterns, and delegates to specialized sub-agents.
 
-### Why Chief-of-Staff?
+#### Why Chief-of-Staff?
 
 - **Questions-first flow**: Collect ALL decisions up front, execute in bulk at the end (faster)
 - **Learns your patterns**: Records your choices vs suggestions, improves accuracy over time
-- **Routes intelligently**: Detects packages, newsletters, and action items - sends them to the right handler
+- **Routes intelligently**: Detects packages, newsletters, and action items, sends them to the right handler
 - **Multiple modes**: Interview mode (voice-friendly), batch mode (visual HTML), digest mode (summaries)
 - **Unified interface**: One plugin, many capabilities
 
-### Quick Start
+#### Quick Start
 
 ```bash
 # 1. Configure your email provider
@@ -86,7 +64,7 @@ Install the main orchestrator plugin:
 /chief-of-staff:batch      # Visual HTML batch mode
 ```
 
-### Commands
+#### Commands
 
 | Command | Description |
 |---------|-------------|
@@ -104,7 +82,7 @@ Install the main orchestrator plugin:
 | `/chief-of-staff:optimize` | Deep folder analysis and suggestions |
 | `/chief-of-staff:rules` | View/manage filing rules |
 
-### Triage Modes
+#### Triage Modes
 
 | Mode | Best For | How It Works |
 |------|----------|--------------|
@@ -112,7 +90,7 @@ Install the main orchestrator plugin:
 | `/chief-of-staff:batch` | Desktop, quick visual review | HTML interface, review all at once |
 | `/chief-of-staff:digest` | Quick status | Summary of automated emails |
 
-### Interview Mode Flow
+#### Interview Mode Flow
 
 ```
 PHASE 1: COLLECT (rapid Q&A)
@@ -128,52 +106,14 @@ PHASE 3: LEARN (improve suggestions)
 -> Update confidence scores
 ```
 
-### Custom Responses During Interview
-
-| You Say | What Happens |
-|---------|--------------|
-| "Need to create a rule" | Archives + creates reminder to make a server-side rule |
-| "Flag for later" | Keeps in inbox + flags for follow-up |
-| "Read and summarize" | Summarizes content, shows at end, then archives/deletes |
-
-### Built-in Sub-Agents
-
-Chief-of-Staff includes these specialized agents that handle specific email types:
-
-#### inbox-to-parcel
-
-Extracts tracking numbers from shipping emails and adds to Parcel app.
-
-- Supports: UPS, FedEx, USPS, DHL, OnTrac, Amazon
-- Moves processed emails to Orders folder
-- **Direct command**: `/chief-of-staff:parcel`
-- **Requires**: Parcel, Playwright MCPs (email loads via ToolSearch)
-
-#### newsletter-unsubscriber
-
-Handles unwanted newsletter unsubscription.
-
-- Detects newsletters via RFC 2369 headers (List-Unsubscribe)
-- Executes via mailto or web forms (uses Playwright)
-- Maintains allowlist of wanted newsletters
-- **Direct command**: `/chief-of-staff:unsubscribe`
-- **Requires**: Playwright MCP (email loads via ToolSearch)
-
-#### inbox-to-reminder
-
-Creates Apple Reminders from emails requiring action.
-
-- Identifies bills, deadlines, follow-ups, meeting requests
-- Creates reminders with appropriate due dates
-- Routes to correct reminder list
-- **Direct command**: `/chief-of-staff:reminders`
-- **Requires**: `apple-pim` plugin (loads via ToolSearch)
-
-#### Other Sub-Agents
+#### Built-in Sub-Agents
 
 | Agent | Purpose |
 |-------|---------|
 | `inbox-interviewer` | Interactive questions-first triage |
+| `inbox-to-parcel` | Package tracking from shipping emails |
+| `inbox-to-reminder` | Create reminders from action items |
+| `newsletter-unsubscriber` | Unsubscribe from newsletters |
 | `digest-generator` | Summarize automated emails |
 | `organization-analyzer` | Analyze Trash/Archive patterns |
 | `pattern-learner` | Bootstrap filing rules from folders |
@@ -181,17 +121,13 @@ Creates Apple Reminders from emails requiring action.
 | `decision-learner` | Learn from triage decisions |
 | `batch-html-generator` | Visual batch triage interface |
 | `batch-processor` | Execute batch triage decisions |
+| `imessage-assistant` | Read and send iMessages via CLI |
 
-### Requirements
-
-- Email MCP server (Fastmail, Gmail, or Outlook) - see setup below
-- Existing folder structure to learn from
-
-### Email MCP Setup (Required)
+#### Email MCP Setup (Required)
 
 **Chief-of-Staff does NOT bundle an email MCP server.** You must configure your email provider separately.
 
-#### Fastmail (Recommended)
+**Fastmail (Recommended)**
 
 Deploy your own Fastmail MCP server using Cloudflare Workers:
 
@@ -202,57 +138,40 @@ Deploy your own Fastmail MCP server using Cloudflare Workers:
 claude mcp add --transport http fastmail https://your-worker.workers.dev/mcp
 ```
 
-#### Gmail
+**Gmail**
 
 **Official Integration:** Google services are available as [official integrations in Claude](https://www.anthropic.com/integrations). Enable Google Drive, Docs, and Gmail directly in Claude's settings.
 
 **MCP Server:** For Claude Code CLI usage, use the Smithery Gmail server:
 - [smithery.ai/server/gmail](https://smithery.ai/server/gmail)
 
-#### Outlook / Microsoft 365
+**Outlook / Microsoft 365**
 
 **Official Integration:** Microsoft services are available as [official integrations in Claude](https://www.anthropic.com/integrations). Enable Outlook, OneDrive, and other M365 services directly in Claude's settings.
 
 **MCP Server:** For Claude Code CLI usage, use the Smithery Outlook server:
 - [smithery.ai/server/outlook](https://smithery.ai/server/outlook)
 
-#### Verification
+#### Provider-Agnostic Architecture
 
-After adding your email MCP, verify it's working:
+Chief-of-Staff agents are **email provider-agnostic**. The active email provider is configured in `settings.yaml`, and agents dynamically load the appropriate email tools via ToolSearch at runtime. Switch email providers by updating `settings.yaml`. No agent changes needed.
 
-```bash
-# Check MCP status
-/mcp
+#### Extending with Private Agents
 
-# Run setup to configure Chief-of-Staff
-/chief-of-staff:setup
-```
+You can add your own private agents for custom workflows:
 
-### Provider-Agnostic Architecture
+1. Create agent files in `plugins/chief-of-staff/agents/`
+2. Add commands in `plugins/chief-of-staff/commands/`
+3. Add skills with domain knowledge in `plugins/chief-of-staff/skills/`
+4. Private agents can call any COS sub-agent via the Task tool
 
-Chief-of-Staff agents are **email provider-agnostic**. The active email provider is configured in `settings.yaml`, and agents dynamically load the appropriate email tools via ToolSearch at runtime.
-
-Only **fixed** integrations (Parcel, Playwright, Apple PIM) are declared in agent frontmatter. This means:
-- Switch email providers by updating `settings.yaml` - no agent changes needed
-- Gmail and Outlook support ready when MCP servers are available
-
-### Private Extensions
-
-Power users can extend Chief-of-Staff with private capabilities by creating a separate private plugin (e.g., `chief-of-staff-private`) that:
-
-1. Adds custom agents for proprietary workflows
-2. Includes a skill that teaches COS about the private agents
-3. Private agents can call COS sub-agents via Task tool
-
-See CLAUDE.md for the private extension pattern.
+See CLAUDE.md for the full plugin development guide.
 
 ---
 
-## travel-agent
+### travel-agent
 
 Flight research and trip tracking using multiple data sources.
-
-### Agents
 
 | Agent | Model | Description |
 |-------|-------|-------------|
@@ -261,136 +180,33 @@ Flight research and trip tracking using multiple data sources.
 | `flighty` | haiku | Query Flighty app for flight tracking |
 | `tripsy` | haiku | Query Tripsy app for trip planning |
 
-### google-flights
-
-Search Google Flights for airfare estimates.
-
-**Best for:** Quick price comparisons, date flexibility research, routing options
-
-**Example:**
-```
-Search business class flights from Seattle to Hong Kong for December 2026
-```
-
-**Requires:** `pip install fast-flights`
-
-### ita-matrix
-
-Search ITA Matrix for detailed fare information.
-
-**Best for:** Fare class research, pricing breakdowns, complex routing rules
-
-**Note:** Uses headed browser (ITA blocks headless). Searches take 2-5 minutes.
-
-**Requires:** `/plugin install playwright@claude-plugins-official`
-
-### flighty
-
-Query Flighty app's local database for flight tracking.
-
-**Commands:**
-| Command | Description |
-|---------|-------------|
-| `list [limit]` | Upcoming flights |
-| `next` | Next upcoming flight |
-| `date YYYY-MM-DD` | Flights on a date |
-| `pnr CODE` | Search by confirmation code |
-| `stats` | Flight statistics |
-| `recent [limit]` | Past flights |
-
-**Requires:** Flighty app on macOS
-
-### tripsy
-
-Query Tripsy app's local database for trip information.
-
-**Commands:**
-| Command | Description |
-|---------|-------------|
-| `list [limit]` | Upcoming trips |
-| `trip "Name"` | Full trip details |
-| `flights [limit]` | Flights across all trips |
-| `hotels [limit]` | Hotel stays |
-
-**Requires:** Tripsy app on macOS
+**Requirements:** `pip install fast-flights` (google-flights), Flighty/Tripsy macOS apps (flighty/tripsy)
 
 ---
 
-## apple-pim
+### apple-pim
 
-Native macOS integration for Calendar, Reminders, Contacts, and Mail using Apple's EventKit, Contacts, and JXA frameworks. Built with Swift CLIs wrapped by a Node.js MCP server.
+Native macOS integration for Calendar, Reminders, Contacts, and Mail using Apple's EventKit, Contacts, and JXA frameworks.
 
 **Source:** [omarshahine/Apple-PIM-Agent-Plugin](https://github.com/omarshahine/Apple-PIM-Agent-Plugin)
 
-> This plugin is sourced from an external GitHub repo - see the link above for full documentation, architecture details, and development instructions.
-
-### Features
-
-- Full CRUD for events, reminders, contacts, and mail messages
-- 32 MCP tools across 4 domains (Calendar, Reminders, Contacts, Mail)
-- Batch operations for creating multiple events or reminders at once
-- Natural language dates ("tomorrow 2pm", "next Tuesday", "in 2 hours")
-- Recurrence rules (daily, weekly, monthly, yearly with patterns)
-- Configurable per-domain enable/disable and calendar/list filtering
-- Used by `chief-of-staff:reminders` for creating reminders from emails
-
-### Installation
-
-```bash
-/plugin install apple-pim@omarshahine-agent-plugins
-
-# Build Swift CLIs and install dependencies
-~/.claude/plugins/cache/omarshahine-agent-plugins/apple-pim/setup.sh
-```
-
-Restart Claude Code to load the MCP server, then grant macOS permissions when prompted (Calendar, Reminders, Contacts). For mail, also grant Automation permission for Mail.app.
-
-### Usage
-
-**Slash commands:**
-```
-/apple-pim:calendars events
-/apple-pim:calendars create "Team Meeting" --start "tomorrow 2pm" --duration 60
-/apple-pim:reminders items --list "Shopping"
-/apple-pim:reminders create "Buy milk" --due "tomorrow"
-/apple-pim:contacts search "John"
-/apple-pim:mail messages --mailbox "INBOX" --filter unread
-```
-
-**Natural language (via pim-assistant agent):**
-```
-Schedule a meeting with the team for next Tuesday at 2pm
-Remind me to call the dentist tomorrow
-What's on my calendar this week?
-Find John's phone number
-Show me unread emails in my inbox
-```
-
-### Commands
+> This plugin is sourced from an external GitHub repo. See the link above for full documentation.
 
 | Command | Description |
 |---------|-------------|
-| `/apple-pim:calendars` | Manage calendar events (list, search, create, update, delete) |
-| `/apple-pim:reminders` | Manage reminders (list, search, create, complete, update, delete) |
-| `/apple-pim:contacts` | Manage contacts (list, search, get details, create, update, delete) |
-| `/apple-pim:mail` | Manage Mail.app messages (list, search, read, flag, move, delete) |
-| `/apple-pim:configure` | Interactive setup - enable/disable domains, filter calendars/lists |
+| `/apple-pim:calendars` | Manage calendar events |
+| `/apple-pim:reminders` | Manage reminders |
+| `/apple-pim:contacts` | Manage contacts |
+| `/apple-pim:mail` | Manage Mail.app messages |
+| `/apple-pim:configure` | Interactive setup |
 
-### Requirements
-
-- macOS 13+ (Ventura or later)
-- Swift 5.9+ (Xcode 15+ or Command Line Tools)
-- Node.js 18+
-- Mail.app must be running for mail commands
-- Grant Calendar, Reminders, Contacts, and Automation permissions when prompted
+**Requirements:** macOS 13+, Swift 5.9+, Node.js 18+
 
 ---
 
-## credit-card-benefits
+### credit-card-benefits
 
 Track and maximize premium credit card benefits with anniversary-aware checklists.
-
-### Supported Cards
 
 | Card | Annual Fee | Key Benefits |
 |------|------------|--------------|
@@ -400,97 +216,27 @@ Track and maximize premium credit card benefits with anniversary-aware checklist
 | Delta SkyMiles Reserve | $650 | Companion cert, Delta Stays, monthly credits |
 | Alaska Airlines Atmos Summit | $395 | Companion fare, lounge passes |
 
-### Quick Start
-
-```bash
-/plugin install credit-card-benefits@omarshahine-agent-plugins
-
-/credit-card-benefits:configure    # Set up cards and data source
-/credit-card-benefits:sync --full  # Pull 12 months to find anniversaries
-/credit-card-benefits:status       # Check your benefits
-```
-
-### Commands
-
 | Command | Description |
 |---------|-------------|
 | `/credit-card-benefits:configure` | Set up cards and data sources |
 | `/credit-card-benefits:sync` | Sync transactions |
 | `/credit-card-benefits:status` | View all benefits |
 | `/credit-card-benefits:remind` | Benefits expiring soon |
-| `/credit-card-benefits:use` | Record benefit usage |
-| `/credit-card-benefits:info` | Card benefit details |
-
-### Data Sources
-
-| Source | Best For |
-|--------|----------|
-| YNAB MCP | YNAB users with MCP server |
-| YNAB API | YNAB users (requires token) |
-| CSV Import | Any card |
-| Manual | Simple tracking |
-
-### Natural Language
-
-```
-What Amex credits do I still need to use?
-Show me my unused Chase Sapphire benefits
-What benefits are expiring this month?
-```
 
 ---
 
-## rename-agent
+### rename-agent
 
-AI-powered file renaming with pattern-based naming.
+AI-powered file renaming with pattern-based naming. Analyzes PDFs, images, and text files for smart classification.
 
-### Features
-
-- Analyzes PDFs, images, and text files
-- Smart classification (15+ document types)
-- Pattern learning for consistent naming
-- Batch processing
-
-### Usage
-
-```
+```bash
 /rename-agent:rename ~/Downloads/tax-docs
 /rename-agent:rename ~/Documents/receipts --pattern "{Date:YYYY-MM-DD} - {Merchant}"
 ```
 
-Or natural language:
-```
-Rename the tax documents in my Downloads folder
-Help me organize these receipts
-```
+**Requirements:** Python 3.10+, `ANTHROPIC_API_KEY`, `pip install claude-rename-agent`
 
-### Pattern Tokens
-
-`{Date:YYYY-MM-DD}`, `{Year}`, `{Merchant}`, `{Amount}`, `{Institution}`, `{Form Type}`, `{Last 4 Digits}`, `{Description}`
-
-### Document Types
-
-Receipt, Bill, Tax Document, Bank Statement, Invoice, Contract, Medical, Insurance, Investment, Payslip, Identity, Correspondence, Manual, Photo, General
-
-### Requirements
-
-- Python 3.10+
-- `ANTHROPIC_API_KEY` environment variable
-- Install: `pip install claude-rename-agent`
-
-**Source:** https://github.com/omarshahine/claude-rename-agent
-
----
-
-## Plugin Reference
-
-| Plugin | Description | Key Commands |
-|--------|-------------|--------------|
-| **chief-of-staff** | Email orchestrator with learning | `/chief-of-staff:triage`, `/chief-of-staff:daily` |
-| travel-agent | Flight research & tracking | Natural language queries |
-| [apple-pim](https://github.com/omarshahine/Apple-PIM-Agent-Plugin) | Calendar, Reminders, Contacts, Mail | `/apple-pim:calendars`, `/apple-pim:reminders`, `/apple-pim:mail` |
-| credit-card-benefits | Benefit tracking | `/credit-card-benefits:status` |
-| rename-agent | File renaming | `/rename-agent:rename` |
+**Source:** [omarshahine/claude-rename-agent](https://github.com/omarshahine/claude-rename-agent)
 
 ---
 
@@ -500,7 +246,8 @@ Receipt, Bill, Tax Document, Bank Statement, Invoice, Contract, Medical, Insuran
 2. Add manifest: `plugins/my-plugin/.claude-plugin/plugin.json`
 3. Add agents, skills, or commands
 4. Register in `.claude-plugin/marketplace.json`
-5. Update this README
+5. Bump the marketplace version
+6. Update this README
 
 ### Plugin Structure
 
@@ -533,90 +280,6 @@ Add to `.claude-plugin/marketplace.json`:
   "category": "productivity"
 }
 ```
-
----
-
-## Migrating from Previous Plugins
-
-If you were using the standalone inbox plugins (inbox-triage, inbox-to-parcel, inbox-to-reminder, newsletter-unsubscriber), follow these steps to migrate to Chief-of-Staff.
-
-### Step 1: Backup Existing Data
-
-```bash
-# Find your old plugin data directories
-ls ~/.claude/plugins/cache/omarshahine-agent-plugins/inbox-triage/data/
-ls ~/.claude/plugins/cache/omarshahine-agent-plugins/inbox-to-parcel/data/
-ls ~/.claude/plugins/cache/omarshahine-agent-plugins/inbox-to-reminder/data/
-ls ~/.claude/plugins/cache/omarshahine-agent-plugins/newsletter-unsubscriber/data/
-
-# Backup important files (filing rules, settings, learned patterns)
-cp ~/.claude/plugins/cache/omarshahine-agent-plugins/inbox-triage/data/*.yaml ~/Desktop/inbox-backup/
-```
-
-### Step 2: Uninstall Old Plugins
-
-```bash
-/plugin uninstall inbox-triage@omarshahine-agent-plugins
-/plugin uninstall inbox-to-parcel@omarshahine-agent-plugins
-/plugin uninstall inbox-to-reminder@omarshahine-agent-plugins
-/plugin uninstall newsletter-unsubscriber@omarshahine-agent-plugins
-```
-
-### Step 3: Install Chief-of-Staff
-
-```bash
-/plugin install chief-of-staff@omarshahine-agent-plugins
-```
-
-### Step 4: Migrate Data
-
-Run the included migration script:
-
-```bash
-~/.claude/plugins/cache/omarshahine-agent-plugins/chief-of-staff/scripts/migrate-data.sh
-```
-
-Or manually copy your data files:
-
-```bash
-# Copy filing rules (most important - your learned patterns)
-cp ~/Desktop/inbox-backup/filing-rules.yaml \
-   ~/.claude/plugins/cache/omarshahine-agent-plugins/chief-of-staff/data/
-
-# Copy user preferences
-cp ~/Desktop/inbox-backup/user-preferences.yaml \
-   ~/.claude/plugins/cache/omarshahine-agent-plugins/chief-of-staff/data/
-
-# Copy settings (review and merge if needed)
-cp ~/Desktop/inbox-backup/settings.yaml \
-   ~/.claude/plugins/cache/omarshahine-agent-plugins/chief-of-staff/data/
-```
-
-### Step 5: Update Your Workflow
-
-| Old Command | New Command |
-|-------------|-------------|
-| `/inbox-triage:interview` | `/chief-of-staff:triage` |
-| `/inbox-triage:batch` | `/chief-of-staff:batch` |
-| `/inbox-triage:learn` | `/chief-of-staff:learn` |
-| `/inbox-triage:digest` | `/chief-of-staff:digest` |
-| `/inbox-triage:rules` | `/chief-of-staff:rules` |
-| `/inbox-triage:analyze` | `/chief-of-staff:analyze` |
-| `/inbox-triage:optimize` | `/chief-of-staff:optimize` |
-| `/inbox-to-parcel:track` | `/chief-of-staff:parcel` |
-| `/inbox-to-reminder:scan` | `/chief-of-staff:reminders` |
-| `/newsletter-unsubscriber:unsubscribe` | `/chief-of-staff:unsubscribe` |
-
-### Data File Mapping
-
-| Old Location | New Location |
-|--------------|--------------|
-| `inbox-triage/data/filing-rules.yaml` | `chief-of-staff/data/filing-rules.yaml` |
-| `inbox-triage/data/user-preferences.yaml` | `chief-of-staff/data/user-preferences.yaml` |
-| `inbox-triage/data/settings.yaml` | `chief-of-staff/data/settings.yaml` |
-| `inbox-triage/data/delete-patterns.yaml` | `chief-of-staff/data/delete-patterns.yaml` |
-| `inbox-to-parcel/data/settings.yaml` | Merged into `chief-of-staff/data/settings.yaml` |
-| `newsletter-unsubscriber/data/newsletter-lists.yaml` | `chief-of-staff/data/newsletter-lists.yaml` |
 
 ---
 

--- a/plugins/chief-of-staff/README.md
+++ b/plugins/chief-of-staff/README.md
@@ -5,7 +5,7 @@ The "one plugin to rule them all" for personal productivity. Chief-of-Staff is a
 ## Installation
 
 ```bash
-/plugin install chief-of-staff@omarshahine-agent-plugins
+/plugin install chief-of-staff@my-plugins
 ```
 
 ## Quick Start
@@ -121,7 +121,7 @@ All data is stored in `data/` (gitignored, with `.example.yaml` templates):
 
 **Optional (enhance functionality):**
 - Parcel API MCP - Package tracking
-- Apple PIM MCP v2.4.0+ - Reminders and calendar with profile support (`/plugin install apple-pim@omarshahine-agent-plugins`)
+- Apple PIM MCP v2.4.0+ - Reminders and calendar with profile support (`/plugin install apple-pim@my-plugins`)
 - Playwright plugin - Newsletter unsubscribe web forms
 
 ## Apple PIM Profile Integration

--- a/plugins/chief-of-staff/agents/inbox-action-creator.md
+++ b/plugins/chief-of-staff/agents/inbox-action-creator.md
@@ -40,7 +40,7 @@ Glob: ~/.claude/plugins/cache/*/chief-of-staff/*/references/inbox-action-pattern
 
 If not found in cache, try the source repo:
 ```
-Glob: ~/GitHub/Agent-Plugins/plugins/chief-of-staff/references/inbox-action-pattern.md
+Glob: ~/GitHub/chief-of-staff-template/plugins/chief-of-staff/references/inbox-action-pattern.md
 ```
 
 This contains all templates and patterns you need. Use it as your source of truth for file formats.

--- a/plugins/chief-of-staff/scripts/migrate-data.sh
+++ b/plugins/chief-of-staff/scripts/migrate-data.sh
@@ -29,7 +29,7 @@ if [[ "$1" == "--dry-run" ]]; then
 fi
 
 # Base paths
-PLUGIN_CACHE="$HOME/.claude/plugins/cache/omarshahine-agent-plugins"
+PLUGIN_CACHE="$HOME/.claude/plugins/cache/my-plugins"
 COS_DATA="$PLUGIN_CACHE/chief-of-staff/data"
 BACKUP_DIR="$HOME/Desktop/inbox-plugins-backup-$(date +%Y%m%d-%H%M%S)"
 
@@ -45,7 +45,7 @@ echo ""
 # Check if chief-of-staff is installed
 if [[ ! -d "$COS_DATA" ]]; then
     echo -e "${RED}Error: Chief-of-Staff plugin not found at $COS_DATA${NC}"
-    echo "Please install it first: /plugin install chief-of-staff@omarshahine-agent-plugins"
+    echo "Please install it first: /plugin install chief-of-staff@my-plugins"
     exit 1
 fi
 
@@ -184,10 +184,10 @@ if [[ "$DRY_RUN" == false ]]; then
     echo "  1. Review merged settings in $COS_DATA/settings.yaml"
     echo "  2. Test with: /chief-of-staff:status"
     echo "  3. If everything works, uninstall old plugins:"
-    echo "     /plugin uninstall inbox-triage@omarshahine-agent-plugins"
-    echo "     /plugin uninstall inbox-to-parcel@omarshahine-agent-plugins"
-    echo "     /plugin uninstall inbox-to-reminder@omarshahine-agent-plugins"
-    echo "     /plugin uninstall newsletter-unsubscriber@omarshahine-agent-plugins"
+    echo "     /plugin uninstall inbox-triage@my-plugins"
+    echo "     /plugin uninstall inbox-to-parcel@my-plugins"
+    echo "     /plugin uninstall inbox-to-reminder@my-plugins"
+    echo "     /plugin uninstall newsletter-unsubscriber@my-plugins"
 else
     echo -e "${YELLOW}DRY RUN complete. Run without --dry-run to perform migration.${NC}"
 fi

--- a/plugins/credit-card-benefits/README.md
+++ b/plugins/credit-card-benefits/README.md
@@ -15,7 +15,7 @@ Track and maximize your premium credit card benefits with anniversary-aware chec
 ## Installation
 
 ```bash
-/plugin install credit-card-benefits@omarshahine-agent-plugins
+/plugin install credit-card-benefits@my-plugins
 ```
 
 ## Quick Start

--- a/plugins/travel-agent/.claude-plugin/plugin.json
+++ b/plugins/travel-agent/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Omar Shahine"
   },
-  "repository": "https://github.com/omarshahine/Agent-Plugins",
+  "repository": "https://github.com/omarshahine/chief-of-staff-template",
   "license": "MIT",
   "keywords": ["travel", "flights", "google-flights", "ita-matrix", "flighty", "tripsy"]
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-# Agent-Plugins Setup Script
+# Chief-of-Staff Template Setup Script
 # Run this after cloning to build MCP servers bundled with plugins
 
 set -e
 
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-echo "Agent-Plugins Setup"
-echo "==================="
+echo "Chief-of-Staff Template Setup"
+echo "=============================="
 echo ""
 
 # Build MCP servers bundled with plugins


### PR DESCRIPTION
## Summary

- Reframe repo as a GitHub template (not a marketplace to install from)
- Rename marketplace from `omarshahine-agent-plugins` to `my-plugins`
- Rewrite README with "Use this template" getting started flow
- Update all install examples to use generic `@my-plugins` name
- Remove migration docs (irrelevant for new template users)
- Keep all four plugins as working examples

## Test plan

- [ ] Verify "Use this template" button appears on GitHub repo page
- [ ] Grep for `omarshahine-agent-plugins` returns 0 matches (outside plugin.json author fields)
- [ ] Grep for `Agent-Plugins` returns 0 matches
- [ ] README instructions make sense for a new user starting from the template

🤖 Generated with [Claude Code](https://claude.com/claude-code)