### PR TITLE
chore: document Clawpatch setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ plugins/*/mcp-server/*/node_modules/
 # Private PII patterns (not tracked in public repo)
 .pii-patterns.local.yaml
 notes.md
+
+# Clawpatch local review state
+.clawpatch/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -526,3 +526,22 @@ Use **major version bumps** (X.0.0 → X+1.0.0) only for:
 | Marketplace-only change | - | ✓ | - |
 
 After version bump, plugins auto-update on next Claude Code session (if auto-updates enabled).
+
+## Clawpatch Code Review
+
+This repo uses [Clawpatch](https://clawpatch.ai) for local automated code review. Keep `.clawpatch/` ignored; it is generated runtime state containing features, findings, reports, runs, and patch attempts.
+
+Standard workflow:
+
+```bash
+clawpatch doctor
+clawpatch init          # first time only
+clawpatch map
+clawpatch review --limit 10
+clawpatch report --output .clawpatch/reports/summary.md
+clawpatch show --finding <id>
+clawpatch fix --finding <id>
+clawpatch revalidate --finding <id>
+```
+
+If this repo needs hand-authored feature coverage, keep those curated definitions in `tools/clawpatch/features/` and sync/copy them into `.clawpatch/features/` before review. Do not commit `.clawpatch/` generated state.


### PR DESCRIPTION
Adds Clawpatch docs and ignore coverage for local review state.